### PR TITLE
feat: support per-source token for private repository access

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ Skills are installed to `~/.agents/skills/` (universal directory) by default, an
 # Add a skill source
 skilltap add anthropics/skills
 
+# Add a private source with a per-source token
+skilltap add company/private-skills --token ghp_xxx
+
 # Remove a source
 skilltap remove anthropics/skills
 
@@ -131,8 +134,11 @@ $ skilltap install pdf --from my-company/skills
 import { Skilltap } from '@eddiearc/skilltap'
 
 const st = new Skilltap({
-  sources: ['anthropics/skills', 'your-company/skills'],
-  token: 'ghp_xxx',              // optional, for private repos
+  sources: [
+    'anthropics/skills',                                    // public source (string)
+    { repo: 'company/private-skills', token: 'ghp_xxx' },  // private source with per-source token
+  ],
+  token: 'ghp_fallback',            // optional, global fallback token
   agents: ['claude-code', 'cursor'], // optional, symlink targets
 })
 
@@ -161,11 +167,11 @@ const agents = await detectInstalledAgents()
 
 ## Authentication
 
-skilltap auto-detects GitHub credentials in this order:
+For each source, tokens are resolved in this order:
 
-1. `gh` CLI config (`~/.config/gh/hosts.yml`)
-2. `GITHUB_TOKEN` environment variable
-3. `~/.skilltap/config.json` token field
+1. **Per-source token** (from `SourceConfig.token`)
+2. **Global token** (from `SkilltapConfig.token` or `~/.skilltap/config.json`)
+3. **Auto-detected credentials** (`gh` CLI config or `GITHUB_TOKEN` env var)
 
 For public repos, no auth is needed.
 
@@ -175,8 +181,12 @@ Config is stored at `~/.skilltap/config.json`:
 
 ```json
 {
-  "sources": ["anthropics/skills"],
-  "installDir": "~/.agents/skills"
+  "sources": [
+    "anthropics/skills",
+    { "repo": "company/private-skills", "token": "ghp_xxx" }
+  ],
+  "installDir": "~/.agents/skills",
+  "token": "ghp_global_fallback"
 }
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -40,6 +40,9 @@ github.com/anthropics/skills/       <- 这就是一个 tap
 # 添加技能源
 skilltap add anthropics/skills
 
+# 添加带独立 token 的私有源
+skilltap add company/private-skills --token ghp_xxx
+
 # 移除源
 skilltap remove anthropics/skills
 
@@ -131,8 +134,11 @@ $ skilltap install pdf --from my-company/skills
 import { Skilltap } from '@eddiearc/skilltap'
 
 const st = new Skilltap({
-  sources: ['anthropics/skills', 'your-company/skills'],
-  token: 'ghp_xxx',              // 可选，用于私有仓库
+  sources: [
+    'anthropics/skills',                                    // 公开源（字符串）
+    { repo: 'company/private-skills', token: 'ghp_xxx' },  // 私有源，带独立 token
+  ],
+  token: 'ghp_fallback',            // 可选，全局兜底 token
   agents: ['claude-code', 'cursor'], // 可选，软链接目标
 })
 
@@ -161,11 +167,11 @@ const agents = await detectInstalledAgents()
 
 ## 鉴权
 
-skilltap 按以下顺序自动检测 GitHub 凭证：
+每个源的 token 按以下优先级解析：
 
-1. `gh` CLI 配置（`~/.config/gh/hosts.yml`）
-2. `GITHUB_TOKEN` 环境变量
-3. `~/.skilltap/config.json` 中的 token 字段
+1. **源级 token**（`SourceConfig.token`）
+2. **全局 token**（`SkilltapConfig.token` 或 `~/.skilltap/config.json`）
+3. **自动检测凭证**（`gh` CLI 配置 或 `GITHUB_TOKEN` 环境变量）
 
 公开仓库无需鉴权。
 
@@ -175,8 +181,12 @@ skilltap 按以下顺序自动检测 GitHub 凭证：
 
 ```json
 {
-  "sources": ["anthropics/skills"],
-  "installDir": "~/.agents/skills"
+  "sources": [
+    "anthropics/skills",
+    { "repo": "company/private-skills", "token": "ghp_xxx" }
+  ],
+  "installDir": "~/.agents/skills",
+  "token": "ghp_global_fallback"
 }
 ```
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -3,7 +3,8 @@ import { Skilltap } from '../core/client.js'
 import { AGENTS, detectInstalledAgents, resolveAgentDirs } from '../core/agents.js'
 import { loadConfig, saveConfig } from './config.js'
 import { SkillConflictError } from '../core/types.js'
-import type { SkilltapConfigFile } from '../core/types.js'
+import type { SkilltapConfigFile, SourceEntry } from '../core/types.js'
+import { sourceEntryRepo } from '../core/github.js'
 
 const program = new Command()
 
@@ -31,15 +32,17 @@ async function resolveAgentOpts(
 program
   .command('add <repo>')
   .description('Add a skill source (e.g. anthropics/skills)')
-  .action(async (repo: string) => {
+  .option('-t, --token <token>', 'GitHub PAT for this source (private repos)')
+  .action(async (repo: string, opts: { token?: string }) => {
     const config = await loadConfig()
-    if (config.sources.includes(repo)) {
+    if (config.sources.some((s) => sourceEntryRepo(s) === repo)) {
       console.log(`Source "${repo}" already added`)
       return
     }
-    config.sources.push(repo)
+    const entry: SourceEntry = opts.token ? { repo, token: opts.token } : repo
+    config.sources.push(entry)
     await saveConfig(config)
-    console.log(`Added source: ${repo}`)
+    console.log(`Added source: ${repo}${opts.token ? ' (with token)' : ''}`)
   })
 
 program
@@ -47,7 +50,7 @@ program
   .description('Remove a skill source')
   .action(async (repo: string) => {
     const config = await loadConfig()
-    config.sources = config.sources.filter((s) => s !== repo)
+    config.sources = config.sources.filter((s) => sourceEntryRepo(s) !== repo)
     await saveConfig(config)
     console.log(`Removed source: ${repo}`)
   })
@@ -176,7 +179,9 @@ program
       return
     }
     for (const source of config.sources) {
-      console.log(`  ${source}`)
+      const repo = sourceEntryRepo(source)
+      const hasToken = typeof source !== 'string' && !!source.token
+      console.log(`  ${repo}${hasToken ? ' (token configured)' : ''}`)
     }
   })
 

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -1,24 +1,27 @@
 import type {
   SkilltapConfig,
+  SourceEntry,
   TapSource,
   RemoteSkill,
   InstalledSkill,
 } from './types.js'
 import { SkillConflictError } from './types.js'
-import { parseSource, listRepoDirs, getSkillMd, parseFrontmatter } from './github.js'
+import { parseSource, parseSourceEntry, resolveToken, listRepoDirs, getSkillMd, parseFrontmatter } from './github.js'
 import { installSkill, uninstallSkill, listInstalled } from './installer.js'
 import { resolveAgentDirs } from './agents.js'
 
 export class Skilltap {
+  private entries: SourceEntry[]
   private sources: TapSource[]
   private installDir?: string
-  private token?: string
+  private globalToken?: string
   private symlinkDirs?: string[]
 
   constructor(config: SkilltapConfig) {
-    this.sources = config.sources.map(parseSource)
+    this.entries = config.sources
+    this.sources = config.sources.map(parseSourceEntry)
     this.installDir = config.installDir
-    this.token = config.token
+    this.globalToken = config.token
 
     // Collect symlink targets: agent dirs + custom dirs
     const dirs: string[] = []
@@ -33,15 +36,22 @@ export class Skilltap {
     }
   }
 
+  /** Resolve the effective token for a source entry */
+  private tokenFor(entry: SourceEntry): string | undefined {
+    return resolveToken(entry, this.globalToken)
+  }
+
   /** List all available skills from all sources */
   async available(): Promise<RemoteSkill[]> {
     const skills: RemoteSkill[] = []
 
-    for (const source of this.sources) {
-      const dirs = await listRepoDirs(source, this.token)
+    for (let i = 0; i < this.sources.length; i++) {
+      const source = this.sources[i]
+      const token = this.tokenFor(this.entries[i])
+      const dirs = await listRepoDirs(source, token)
 
       for (const dir of dirs) {
-        const content = await getSkillMd(source, dir, this.token)
+        const content = await getSkillMd(source, dir, token)
         if (!content) continue
 
         const meta = parseFrontmatter(content)
@@ -70,14 +80,23 @@ export class Skilltap {
     // Explicit source specified — skip conflict detection
     if (opts?.from) {
       const source = parseSource(opts.from)
-      return installSkill(source, skillName, this.installDir, this.token, this.symlinkDirs)
+      // Find matching entry for token resolution
+      const matchEntry = this.entries.find(
+        (e) => {
+          const repo = typeof e === 'string' ? e : e.repo
+          return repo === opts.from
+        },
+      )
+      const token = matchEntry ? this.tokenFor(matchEntry) : this.globalToken
+      return installSkill(source, skillName, this.installDir, token, this.symlinkDirs)
     }
 
     // Find all sources that have this skill
-    const matches: TapSource[] = []
-    for (const source of this.sources) {
-      const content = await getSkillMd(source, skillName, this.token)
-      if (content) matches.push(source)
+    const matches: { source: TapSource; entry: SourceEntry }[] = []
+    for (let i = 0; i < this.sources.length; i++) {
+      const token = this.tokenFor(this.entries[i])
+      const content = await getSkillMd(this.sources[i], skillName, token)
+      if (content) matches.push({ source: this.sources[i], entry: this.entries[i] })
     }
 
     if (matches.length === 0) {
@@ -87,11 +106,12 @@ export class Skilltap {
     if (matches.length > 1) {
       throw new SkillConflictError(
         skillName,
-        matches.map((s) => `${s.owner}/${s.repo}`),
+        matches.map((m) => `${m.source.owner}/${m.source.repo}`),
       )
     }
 
-    return installSkill(matches[0], skillName, this.installDir, this.token, this.symlinkDirs)
+    const token = this.tokenFor(matches[0].entry)
+    return installSkill(matches[0].source, skillName, this.installDir, token, this.symlinkDirs)
   }
 
   /** Uninstall a skill */

--- a/src/core/github.ts
+++ b/src/core/github.ts
@@ -1,4 +1,4 @@
-import type { TapSource, SkillMeta } from './types.js'
+import type { TapSource, SkillMeta, SourceEntry } from './types.js'
 
 const GITHUB_API = 'https://api.github.com'
 
@@ -23,6 +23,28 @@ export function parseSource(source: string): TapSource {
   const [owner, repo] = source.split('/')
   if (!owner || !repo) throw new Error(`Invalid source: "${source}", expected "owner/repo"`)
   return { owner, repo }
+}
+
+/** Parse a SourceEntry (string or SourceConfig) into TapSource */
+export function parseSourceEntry(entry: SourceEntry): TapSource {
+  if (typeof entry === 'string') return parseSource(entry)
+  const source = parseSource(entry.repo)
+  if (entry.branch) source.branch = entry.branch
+  return source
+}
+
+/** Get the repo string from a SourceEntry */
+export function sourceEntryRepo(entry: SourceEntry): string {
+  return typeof entry === 'string' ? entry : entry.repo
+}
+
+/**
+ * Resolve the token for a source entry.
+ * Priority: per-source token > global token > undefined (auto-detect)
+ */
+export function resolveToken(entry: SourceEntry, globalToken?: string): string | undefined {
+  if (typeof entry !== 'string' && entry.token) return entry.token
+  return globalToken
 }
 
 /** List top-level directories in a repo (each dir = potential skill) */

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -31,13 +31,26 @@ export interface InstalledSkill {
   source?: TapSource
 }
 
+/** Per-source configuration with optional token */
+export interface SourceConfig {
+  /** GitHub repo in "owner/repo" format */
+  repo: string
+  /** Optional per-source PAT for private repos */
+  token?: string
+  /** Optional branch override */
+  branch?: string
+}
+
+/** A source entry — either a string "owner/repo" or a SourceConfig object */
+export type SourceEntry = string | SourceConfig
+
 /** Skilltap client configuration */
 export interface SkilltapConfig {
-  /** GitHub repos to use as skill sources, e.g. ['anthropics/skills'] */
-  sources: string[]
+  /** GitHub repos to use as skill sources — strings or SourceConfig objects */
+  sources: SourceEntry[]
   /** Primary directory to install skills into (default: ~/.claude/skills) */
   installDir?: string
-  /** GitHub personal access token for private repos */
+  /** GitHub personal access token for private repos (global fallback) */
   token?: string
   /** Target agent ids to symlink skills to, e.g. ['cursor', 'codex'] */
   agents?: string[]
@@ -59,7 +72,7 @@ export class SkillConflictError extends Error {
 
 /** Skilltap config file stored at ~/.skilltap/config.json */
 export interface SkilltapConfigFile {
-  sources: string[]
+  sources: SourceEntry[]
   installDir: string
   token?: string
   agents?: string[]

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,8 @@ export { SkillConflictError } from './core/types.js'
 export { AGENTS, getAgent, getAgentIds, detectInstalledAgents, resolveAgentDirs } from './core/agents.js'
 export type {
   SkilltapConfig,
+  SourceConfig,
+  SourceEntry,
   TapSource,
   SkillMeta,
   RemoteSkill,

--- a/tests/cli/config.test.ts
+++ b/tests/cli/config.test.ts
@@ -74,3 +74,38 @@ describe('saveConfig', () => {
     )
   })
 })
+
+describe('mixed SourceEntry config', () => {
+  it('loads config with mixed string and SourceConfig sources', async () => {
+    vi.mocked(fs.readFile).mockResolvedValue(
+      JSON.stringify({
+        sources: ['anthropics/skills', { repo: 'company/private', token: 'ghp_xxx' }],
+      }),
+    )
+
+    const config = await loadConfig()
+
+    expect(config.sources).toEqual([
+      'anthropics/skills',
+      { repo: 'company/private', token: 'ghp_xxx' },
+    ])
+  })
+
+  it('saves config with mixed sources correctly', async () => {
+    const config = {
+      sources: [
+        'anthropics/skills' as string | { repo: string; token?: string },
+        { repo: 'company/private', token: 'ghp_xxx' },
+      ],
+      installDir: '/mock-home/.agents/skills',
+    }
+
+    await saveConfig(config)
+
+    expect(fs.writeFile).toHaveBeenCalledWith(
+      '/mock-home/.skilltap/config.json',
+      JSON.stringify(config, null, 2),
+      'utf-8',
+    )
+  })
+})

--- a/tests/core/client.test.ts
+++ b/tests/core/client.test.ts
@@ -6,6 +6,19 @@ vi.mock('../../src/core/github.js', () => ({
     if (!owner || !repo) throw new Error(`Invalid source: "${s}"`)
     return { owner, repo }
   }),
+  parseSourceEntry: vi.fn((entry: string | { repo: string; branch?: string }) => {
+    const s = typeof entry === 'string' ? entry : entry.repo
+    const [owner, repo] = s.split('/')
+    if (!owner || !repo) throw new Error(`Invalid source: "${s}"`)
+    const result: { owner: string; repo: string; branch?: string } = { owner, repo }
+    if (typeof entry !== 'string' && entry.branch) result.branch = entry.branch
+    return result
+  }),
+  sourceEntryRepo: vi.fn((entry: string | { repo: string }) => typeof entry === 'string' ? entry : entry.repo),
+  resolveToken: vi.fn((entry: string | { token?: string }, globalToken?: string) => {
+    if (typeof entry !== 'string' && entry.token) return entry.token
+    return globalToken
+  }),
   listRepoDirs: vi.fn().mockResolvedValue([]),
   getSkillMd: vi.fn().mockResolvedValue(null),
   parseFrontmatter: vi.fn().mockReturnValue(null),
@@ -326,6 +339,112 @@ describe('dirs config', () => {
     expect(installSkill).toHaveBeenCalledWith(
       expect.anything(), 'pdf', undefined, undefined,
       ['/mock-home/.cursor/skills', '/extra/skills'],
+    )
+  })
+})
+
+// --- per-source token ---
+
+describe('per-source token', () => {
+  it('uses per-source token when source has its own token', async () => {
+    vi.mocked(getSkillMd).mockResolvedValue('content')
+
+    const st = new Skilltap({
+      sources: [{ repo: 'company/private', token: 'ghp_source' }],
+      token: 'ghp_global',
+    })
+    await st.install('pdf')
+
+    // Per-source token should be passed (not global)
+    expect(installSkill).toHaveBeenCalledWith(
+      { owner: 'company', repo: 'private' }, 'pdf', undefined, 'ghp_source', undefined,
+    )
+  })
+
+  it('falls back to global token when source has no token', async () => {
+    vi.mocked(getSkillMd).mockResolvedValue('content')
+
+    const st = new Skilltap({
+      sources: ['company/public'],
+      token: 'ghp_global',
+    })
+    await st.install('pdf')
+
+    expect(installSkill).toHaveBeenCalledWith(
+      { owner: 'company', repo: 'public' }, 'pdf', undefined, 'ghp_global', undefined,
+    )
+  })
+
+  it('passes undefined token when neither source nor global token set', async () => {
+    vi.mocked(getSkillMd).mockResolvedValue('content')
+
+    const st = new Skilltap({ sources: ['public/repo'] })
+    await st.install('pdf')
+
+    expect(installSkill).toHaveBeenCalledWith(
+      { owner: 'public', repo: 'repo' }, 'pdf', undefined, undefined, undefined,
+    )
+  })
+
+  it('uses per-source token for available() API calls', async () => {
+    vi.mocked(listRepoDirs).mockResolvedValue(['pdf'])
+    vi.mocked(getSkillMd).mockResolvedValue('---\nname: pdf\ndescription: test\n---')
+    vi.mocked(parseFrontmatter).mockReturnValue({ name: 'pdf', description: 'test' })
+
+    const st = new Skilltap({
+      sources: [{ repo: 'company/private', token: 'ghp_source' }],
+      token: 'ghp_global',
+    })
+    await st.available()
+
+    // Per-source token should be passed to listRepoDirs and getSkillMd
+    expect(listRepoDirs).toHaveBeenCalledWith({ owner: 'company', repo: 'private' }, 'ghp_source')
+    expect(getSkillMd).toHaveBeenCalledWith({ owner: 'company', repo: 'private' }, 'pdf', 'ghp_source')
+  })
+
+  it('handles mixed string and SourceConfig sources', async () => {
+    vi.mocked(listRepoDirs).mockResolvedValue(['pdf'])
+    vi.mocked(getSkillMd).mockResolvedValue('---\nname: pdf\ndescription: test\n---')
+    vi.mocked(parseFrontmatter).mockReturnValue({ name: 'pdf', description: 'test' })
+
+    const st = new Skilltap({
+      sources: ['public/repo', { repo: 'company/private', token: 'ghp_private' }],
+      token: 'ghp_global',
+    })
+    await st.available()
+
+    // First source (string) uses global token
+    expect(listRepoDirs).toHaveBeenCalledWith({ owner: 'public', repo: 'repo' }, 'ghp_global')
+    // Second source (SourceConfig) uses per-source token
+    expect(listRepoDirs).toHaveBeenCalledWith({ owner: 'company', repo: 'private' }, 'ghp_private')
+  })
+
+  it('accepts SourceConfig in constructor without error', () => {
+    expect(() => new Skilltap({
+      sources: [
+        'anthropics/skills',
+        { repo: 'company/private', token: 'ghp_xxx' },
+        { repo: 'other/repo', branch: 'dev' },
+      ],
+    })).not.toThrow()
+  })
+
+  it('resolves per-source token for install with --from matching a SourceConfig', async () => {
+    vi.mocked(installSkill).mockResolvedValue({
+      name: 'pdf',
+      meta: { name: 'pdf', description: 'PDF skill' },
+      path: '/skills/pdf',
+      source: { owner: 'company', repo: 'private' },
+    })
+
+    const st = new Skilltap({
+      sources: ['public/repo', { repo: 'company/private', token: 'ghp_private' }],
+      token: 'ghp_global',
+    })
+    await st.install('pdf', { from: 'company/private' })
+
+    expect(installSkill).toHaveBeenCalledWith(
+      { owner: 'company', repo: 'private' }, 'pdf', undefined, 'ghp_private', undefined,
     )
   })
 })

--- a/tests/core/github.test.ts
+++ b/tests/core/github.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { parseSource, listRepoDirs, getSkillMd, downloadSkillDir, downloadFile, parseFrontmatter } from '../../src/core/github.js'
+import { parseSource, parseSourceEntry, sourceEntryRepo, resolveToken, listRepoDirs, getSkillMd, downloadSkillDir, downloadFile, parseFrontmatter } from '../../src/core/github.js'
 import {
   VALID_SKILL_MD,
   MINIMAL_SKILL_MD,
@@ -76,6 +76,68 @@ describe('parseFrontmatter', () => {
   it('handles colons in values', () => {
     const meta = parseFrontmatter(COLON_IN_VALUE_SKILL_MD)
     expect(meta!.description).toBe('Note: this has a colon in the value')
+  })
+})
+
+// --- parseSourceEntry ---
+
+describe('parseSourceEntry', () => {
+  it('parses string entry like parseSource', () => {
+    expect(parseSourceEntry('owner/repo')).toEqual({ owner: 'owner', repo: 'repo' })
+  })
+
+  it('parses SourceConfig object', () => {
+    expect(parseSourceEntry({ repo: 'owner/repo' })).toEqual({ owner: 'owner', repo: 'repo' })
+  })
+
+  it('preserves branch from SourceConfig', () => {
+    expect(parseSourceEntry({ repo: 'owner/repo', branch: 'dev' })).toEqual({ owner: 'owner', repo: 'repo', branch: 'dev' })
+  })
+
+  it('ignores token (token is not part of TapSource)', () => {
+    const result = parseSourceEntry({ repo: 'owner/repo', token: 'ghp_xxx' })
+    expect(result).toEqual({ owner: 'owner', repo: 'repo' })
+    expect((result as any).token).toBeUndefined()
+  })
+
+  it('throws on invalid SourceConfig repo', () => {
+    expect(() => parseSourceEntry({ repo: 'invalid' })).toThrow('Invalid source')
+  })
+})
+
+// --- sourceEntryRepo ---
+
+describe('sourceEntryRepo', () => {
+  it('returns string as-is', () => {
+    expect(sourceEntryRepo('owner/repo')).toBe('owner/repo')
+  })
+
+  it('returns repo from SourceConfig', () => {
+    expect(sourceEntryRepo({ repo: 'owner/repo', token: 'ghp_xxx' })).toBe('owner/repo')
+  })
+})
+
+// --- resolveToken ---
+
+describe('resolveToken', () => {
+  it('returns per-source token when present', () => {
+    expect(resolveToken({ repo: 'o/r', token: 'ghp_source' }, 'ghp_global')).toBe('ghp_source')
+  })
+
+  it('falls back to global token for SourceConfig without token', () => {
+    expect(resolveToken({ repo: 'o/r' }, 'ghp_global')).toBe('ghp_global')
+  })
+
+  it('falls back to global token for string entry', () => {
+    expect(resolveToken('o/r', 'ghp_global')).toBe('ghp_global')
+  })
+
+  it('returns undefined when no tokens available', () => {
+    expect(resolveToken('o/r')).toBeUndefined()
+  })
+
+  it('returns undefined when SourceConfig has no token and no global', () => {
+    expect(resolveToken({ repo: 'o/r' })).toBeUndefined()
   })
 })
 


### PR DESCRIPTION
## Summary

- Add `SourceConfig` interface with per-source `token` and `branch` fields
- `SkilltapConfig.sources` now accepts `Array<string | SourceConfig>` (backward-compatible)
- Token resolution priority: per-source token > global token > auto-detected credentials
- CLI `add` command supports `--token` flag for private sources
- `sources` and `remove` commands handle mixed source types

## Changes

| File | Change |
|------|--------|
| `src/core/types.ts` | Add `SourceConfig`, `SourceEntry` types; update `SkilltapConfig` and `SkilltapConfigFile` |
| `src/core/github.ts` | Add `parseSourceEntry()`, `sourceEntryRepo()`, `resolveToken()` helpers |
| `src/core/client.ts` | Use per-source token resolution in `available()`, `install()`, `search()` |
| `src/cli/index.ts` | Add `--token` flag to `add`; update `remove` and `sources` for mixed types |
| `src/index.ts` | Export new types |
| `README.md` / `README.zh-CN.md` | Document per-source token config, updated auth priority docs |
| Tests | 89 tests passing — added tests for token resolution, mixed sources, SourceConfig parsing |

## Test plan

- [x] All 89 unit tests pass
- [x] TypeScript compiles with no errors
- [x] Build succeeds (tsup)
- [x] Backward compatible — existing string sources work unchanged

Closes #1