### PR TITLE
feat: support recursive skill discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # skilltap
 
-One repo = one skill market.
+One repo = one skill market, even when skills live in nested folders.
 
 Install AI agent skills from GitHub repos — with multi-agent support.
 
@@ -18,15 +18,18 @@ npm install @eddiearc/skilltap
 
 ## Concept
 
-A **tap** is a GitHub repository containing AI agent skills (directories with `SKILL.md`). Add a tap, then browse and install skills from it.
+A **tap** is a GitHub repository containing AI agent skills (directories with `SKILL.md`). `skilltap` recursively discovers skill folders, so it works with both flat repos and nested layouts such as `skills/pdf/SKILL.md`.
 
 ```
 github.com/anthropics/skills/       <- this is a tap
-├── pdf/
-│   └── SKILL.md
-├── frontend-design/
-│   └── SKILL.md
-└── canvas-design/
+├── skills/
+│   ├── pdf/
+│   │   └── SKILL.md
+│   ├── frontend-design/
+│   │   └── SKILL.md
+│   └── canvas-design/
+│       └── SKILL.md
+└── template/
     └── SKILL.md
 ```
 
@@ -113,6 +116,19 @@ Skills are stored as real files in `~/.agents/skills/` and symlinked to each age
 
 Supported agents: Claude Code, Codex, Cursor, Windsurf, GitHub Copilot, Gemini CLI, Cline, Roo Code, Amp, Augment.
 
+## Skill Discovery
+
+The skill format is based on the Agent Skills convention: a skill is a directory containing a `SKILL.md` file with YAML frontmatter and markdown instructions.
+
+`skilltap` treats a source repo as a directory tree and discovers skills with this rule:
+
+1. Start at the repo root.
+2. For each subdirectory, check whether it directly contains `SKILL.md`.
+3. If yes, register that directory as a skill and stop descending into it.
+4. If not, continue recursively through its child directories.
+
+This matches the current `anthropics/skills` layout, where most skills live under `skills/`, while still supporting flat repositories.
+
 ### Conflict Resolution
 
 When multiple sources have a skill with the same name:
@@ -148,7 +164,7 @@ const results = await st.search('pdf')
 
 // Install & manage
 await st.install('pdf')
-await st.install('pdf', { from: 'anthropic/skills' })
+await st.install('pdf', { from: 'anthropics/skills' })
 await st.uninstall('pdf')
 await st.update()
 
@@ -189,6 +205,16 @@ Config is stored at `~/.skilltap/config.json`:
   "token": "ghp_global_fallback"
 }
 ```
+
+## Versioning And Release
+
+The CLI version is read from `package.json`, so `skilltap --version` stays aligned with the published package version.
+
+The release workflow also uses `package.json` as the source of truth:
+
+1. Read `package.json.version`
+2. Publish that package version to npm
+3. Create and push the matching Git tag (`v<version>`)
 
 ## License
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,6 +1,6 @@
 # skilltap
 
-一个仓库就是一个技能市场。
+一个仓库就是一个技能市场，即使技能放在多层子目录里也一样。
 
 从 GitHub 仓库安装 AI Agent 技能，支持多 Agent 分发。
 
@@ -18,15 +18,18 @@ npm install @eddiearc/skilltap
 
 ## 概念
 
-一个 **tap** 就是一个包含 AI Agent 技能的 GitHub 仓库（每个目录含 `SKILL.md`）。添加一个 tap，就能浏览和安装里面的技能。
+一个 **tap** 就是一个包含 AI Agent 技能的 GitHub 仓库（技能目录里带 `SKILL.md`）。`skilltap` 会递归发现技能目录，因此既支持扁平结构，也支持 `skills/pdf/SKILL.md` 这种多层布局。
 
 ```
 github.com/anthropics/skills/       <- 这就是一个 tap
-├── pdf/
-│   └── SKILL.md
-├── frontend-design/
-│   └── SKILL.md
-└── canvas-design/
+├── skills/
+│   ├── pdf/
+│   │   └── SKILL.md
+│   ├── frontend-design/
+│   │   └── SKILL.md
+│   └── canvas-design/
+│       └── SKILL.md
+└── template/
     └── SKILL.md
 ```
 
@@ -113,6 +116,19 @@ skilltap agents
 
 支持的 Agent：Claude Code、Codex、Cursor、Windsurf、GitHub Copilot、Gemini CLI、Cline、Roo Code、Amp、Augment。
 
+## 技能发现规则
+
+Skill 的核心规范是：一个技能就是一个包含 `SKILL.md` 的目录，`SKILL.md` 里放 YAML frontmatter 和 Markdown 指令。
+
+`skilltap` 现在按下面的规则发现技能：
+
+1. 从仓库根目录开始遍历。
+2. 对每个子目录检查它是否直接包含 `SKILL.md`。
+3. 如果包含，就把该目录认定为一个 skill，并停止继续向下遍历这个目录。
+4. 如果不包含，就继续递归检查它的子目录。
+
+这样既兼容早期的扁平结构，也兼容 `anthropics/skills` 当前把大部分技能放在 `skills/` 子目录里的结构。
+
 ### 冲突处理
 
 当多个源有同名技能时：
@@ -148,7 +164,7 @@ const results = await st.search('pdf')
 
 // 安装和管理
 await st.install('pdf')
-await st.install('pdf', { from: 'anthropic/skills' })
+await st.install('pdf', { from: 'anthropics/skills' })
 await st.uninstall('pdf')
 await st.update()
 
@@ -189,6 +205,16 @@ const agents = await detectInstalledAgents()
   "token": "ghp_global_fallback"
 }
 ```
+
+## 版本与发布
+
+CLI 版本号现在直接读取 `package.json`，因此 `skilltap --version` 会和实际发布包版本保持一致。
+
+发布流程也以 `package.json` 为单一真相源：
+
+1. 读取 `package.json.version`
+2. 发布对应 npm 包版本
+3. 创建并推送匹配的 Git Tag：`v<version>`
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eddiearc/skilltap",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Install AI agent skills from GitHub repos. One repo = one skill tap.",
   "type": "module",
   "main": "./dist/index.js",
@@ -20,7 +20,7 @@
     "lint": "eslint src/",
     "test": "vitest run",
     "test:watch": "vitest --watch",
-    "test:e2e": "vitest run tests/e2e/",
+    "test:e2e": "vitest run --config vitest.e2e.config.ts",
     "prepublishOnly": "pnpm build"
   },
   "keywords": [

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -2,6 +2,7 @@ import { Command } from 'commander'
 import { Skilltap } from '../core/client.js'
 import { AGENTS, detectInstalledAgents, resolveAgentDirs } from '../core/agents.js'
 import { loadConfig, saveConfig } from './config.js'
+import { getCliVersion } from './version.js'
 import { SkillConflictError } from '../core/types.js'
 import type { SkilltapConfigFile, SourceEntry } from '../core/types.js'
 import { sourceEntryRepo } from '../core/github.js'
@@ -11,7 +12,7 @@ const program = new Command()
 program
   .name('skilltap')
   .description('Install AI agent skills from GitHub repos')
-  .version('0.1.0')
+  .version(await getCliVersion())
 
 /** Resolve agent options into config.agents and config.dirs */
 async function resolveAgentOpts(

--- a/src/cli/version.ts
+++ b/src/cli/version.ts
@@ -1,0 +1,17 @@
+import fs from 'node:fs/promises'
+
+let cachedVersion: string | null = null
+
+export async function getCliVersion(): Promise<string> {
+  if (cachedVersion) return cachedVersion
+
+  const raw = await fs.readFile(new URL('../../package.json', import.meta.url), 'utf-8')
+  const pkg = JSON.parse(raw) as { version?: string }
+
+  if (!pkg.version) {
+    throw new Error('package.json is missing a version field')
+  }
+
+  cachedVersion = pkg.version
+  return cachedVersion
+}

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -4,9 +4,10 @@ import type {
   TapSource,
   RemoteSkill,
   InstalledSkill,
+  DiscoveredSkill,
 } from './types.js'
 import { SkillConflictError } from './types.js'
-import { parseSource, parseSourceEntry, resolveToken, listRepoDirs, getSkillMd, parseFrontmatter } from './github.js'
+import { parseSource, parseSourceEntry, resolveToken, findSkills } from './github.js'
 import { installSkill, uninstallSkill, listInstalled } from './installer.js'
 import { resolveAgentDirs } from './agents.js'
 
@@ -41,23 +42,23 @@ export class Skilltap {
     return resolveToken(entry, this.globalToken)
   }
 
+  private async discoverSourceSkills(
+    source: TapSource,
+    entry: SourceEntry | undefined,
+  ): Promise<DiscoveredSkill[]> {
+    return findSkills(source, entry ? this.tokenFor(entry) : this.globalToken)
+  }
+
   /** List all available skills from all sources */
   async available(): Promise<RemoteSkill[]> {
     const skills: RemoteSkill[] = []
 
     for (let i = 0; i < this.sources.length; i++) {
       const source = this.sources[i]
-      const token = this.tokenFor(this.entries[i])
-      const dirs = await listRepoDirs(source, token)
+      const discovered = await this.discoverSourceSkills(source, this.entries[i])
 
-      for (const dir of dirs) {
-        const content = await getSkillMd(source, dir, token)
-        if (!content) continue
-
-        const meta = parseFrontmatter(content)
-        if (!meta) continue
-
-        skills.push({ name: dir, meta, source, path: dir })
+      for (const skill of discovered) {
+        skills.push({ ...skill, source })
       }
     }
 
@@ -88,15 +89,20 @@ export class Skilltap {
         },
       )
       const token = matchEntry ? this.tokenFor(matchEntry) : this.globalToken
-      return installSkill(source, skillName, this.installDir, token, this.symlinkDirs)
+      const discovered = await this.discoverSourceSkills(source, matchEntry)
+      const match = discovered.find((skill) => skill.name === skillName)
+      if (!match) {
+        throw new Error(`Skill "${skillName}" not found in source "${opts.from}"`)
+      }
+      return installSkill(source, skillName, this.installDir, token, this.symlinkDirs, match.path)
     }
 
     // Find all sources that have this skill
-    const matches: { source: TapSource; entry: SourceEntry }[] = []
+    const matches: { source: TapSource; entry: SourceEntry; skill: DiscoveredSkill }[] = []
     for (let i = 0; i < this.sources.length; i++) {
-      const token = this.tokenFor(this.entries[i])
-      const content = await getSkillMd(this.sources[i], skillName, token)
-      if (content) matches.push({ source: this.sources[i], entry: this.entries[i] })
+      const discovered = await this.discoverSourceSkills(this.sources[i], this.entries[i])
+      const match = discovered.find((skill) => skill.name === skillName)
+      if (match) matches.push({ source: this.sources[i], entry: this.entries[i], skill: match })
     }
 
     if (matches.length === 0) {
@@ -111,7 +117,7 @@ export class Skilltap {
     }
 
     const token = this.tokenFor(matches[0].entry)
-    return installSkill(matches[0].source, skillName, this.installDir, token, this.symlinkDirs)
+    return installSkill(matches[0].source, skillName, this.installDir, token, this.symlinkDirs, matches[0].skill.path)
   }
 
   /** Uninstall a skill */

--- a/src/core/github.ts
+++ b/src/core/github.ts
@@ -1,4 +1,4 @@
-import type { TapSource, SkillMeta, SourceEntry } from './types.js'
+import type { TapSource, SkillMeta, SourceEntry, DiscoveredSkill } from './types.js'
 
 const GITHUB_API = 'https://api.github.com'
 
@@ -7,6 +7,32 @@ interface GitHubContent {
   path: string
   type: 'file' | 'dir'
   download_url: string | null
+}
+
+function normalizeRepoPath(repoPath: string): string {
+  return repoPath.replace(/^\/+|\/+$/g, '')
+}
+
+function joinRepoPath(parent: string, child: string): string {
+  return normalizeRepoPath([parent, child].filter(Boolean).join('/'))
+}
+
+function resolveContentPath(parent: string, item: Pick<GitHubContent, 'name' | 'path'>): string {
+  if (!parent) return normalizeRepoPath(item.path || item.name)
+  if (item.path && item.path.includes('/')) return normalizeRepoPath(item.path)
+  return joinRepoPath(parent, item.name)
+}
+
+async function listRepoContents(
+  source: TapSource,
+  token?: string,
+  repoPath = '',
+): Promise<GitHubContent[]> {
+  const normalizedPath = normalizeRepoPath(repoPath)
+  const url = `${GITHUB_API}/repos/${source.owner}/${source.repo}/contents/${normalizedPath}`
+  const res = await fetch(url, { headers: headers(token) })
+  if (!res.ok) throw new Error(`GitHub API error: ${res.status} ${res.statusText}`)
+  return res.json()
 }
 
 function headers(token?: string): Record<string, string> {
@@ -49,11 +75,7 @@ export function resolveToken(entry: SourceEntry, globalToken?: string): string |
 
 /** List top-level directories in a repo (each dir = potential skill) */
 export async function listRepoDirs(source: TapSource, token?: string): Promise<string[]> {
-  const url = `${GITHUB_API}/repos/${source.owner}/${source.repo}/contents/`
-  const res = await fetch(url, { headers: headers(token) })
-  if (!res.ok) throw new Error(`GitHub API error: ${res.status} ${res.statusText}`)
-
-  const items: GitHubContent[] = await res.json()
+  const items = await listRepoContents(source, token)
   return items
     .filter((item) => item.type === 'dir' && !item.name.startsWith('.'))
     .map((item) => item.name)
@@ -62,10 +84,10 @@ export async function listRepoDirs(source: TapSource, token?: string): Promise<s
 /** Check if a directory contains SKILL.md */
 export async function getSkillMd(
   source: TapSource,
-  skillName: string,
+  skillPath: string,
   token?: string,
 ): Promise<string | null> {
-  const url = `${GITHUB_API}/repos/${source.owner}/${source.repo}/contents/${skillName}/SKILL.md`
+  const url = `${GITHUB_API}/repos/${source.owner}/${source.repo}/contents/${normalizeRepoPath(skillPath)}/SKILL.md`
   const res = await fetch(url, {
     headers: { ...headers(token), Accept: 'application/vnd.github.v3.raw' },
   })
@@ -77,13 +99,10 @@ export async function getSkillMd(
 /** Download a skill directory as tarball and return file entries */
 export async function downloadSkillDir(
   source: TapSource,
-  skillName: string,
+  skillPath: string,
   token?: string,
 ): Promise<GitHubContent[]> {
-  const url = `${GITHUB_API}/repos/${source.owner}/${source.repo}/contents/${skillName}`
-  const res = await fetch(url, { headers: headers(token) })
-  if (!res.ok) throw new Error(`GitHub API error: ${res.status} ${res.statusText}`)
-  return res.json()
+  return listRepoContents(source, token, skillPath)
 }
 
 /** Download a single file's raw content */
@@ -117,4 +136,32 @@ export function parseFrontmatter(content: string): SkillMeta | null {
     }
   }
   return meta.name ? meta : null
+}
+
+/** Recursively discover skill directories by locating SKILL.md files */
+export async function findSkills(
+  source: TapSource,
+  token?: string,
+  repoPath = '',
+): Promise<DiscoveredSkill[]> {
+  const items = await listRepoContents(source, token, repoPath)
+  const dirs = items.filter((item) => item.type === 'dir' && !item.name.startsWith('.'))
+  const skills: DiscoveredSkill[] = []
+
+  for (const dir of dirs) {
+    const dirPath = resolveContentPath(repoPath, dir)
+    const skillMd = await getSkillMd(source, dirPath, token)
+
+    if (skillMd) {
+      const meta = parseFrontmatter(skillMd)
+      if (meta) {
+        skills.push({ name: meta.name, meta, path: dirPath })
+      }
+      continue
+    }
+
+    skills.push(...await findSkills(source, token, dirPath))
+  }
+
+  return skills
 }

--- a/src/core/installer.ts
+++ b/src/core/installer.ts
@@ -3,7 +3,7 @@ import path from 'node:path'
 import os from 'node:os'
 
 import type { TapSource, InstalledSkill } from './types.js'
-import { downloadSkillDir, downloadFile, getSkillMd, parseFrontmatter } from './github.js'
+import { downloadSkillDir, downloadFile, parseFrontmatter } from './github.js'
 
 const DEFAULT_INSTALL_DIR = path.join(os.homedir(), '.agents', 'skills')
 
@@ -26,11 +26,12 @@ export async function installSkill(
   installDir = DEFAULT_INSTALL_DIR,
   token?: string,
   symlinkDirs?: string[],
+  remotePath = skillName,
 ): Promise<InstalledSkill> {
   const targetDir = path.join(installDir, skillName)
   await ensureDir(targetDir)
 
-  const files = await downloadSkillDir(source, skillName, token)
+  const files = await downloadSkillDir(source, remotePath, token)
 
   for (const file of files) {
     if (file.type === 'file' && file.download_url) {
@@ -41,7 +42,8 @@ export async function installSkill(
       // Recursively download subdirectories
       const subDir = path.join(targetDir, file.name)
       await ensureDir(subDir)
-      const subFiles = await downloadSkillDir(source, `${skillName}/${file.name}`, token)
+      const subPath = file.path.includes('/') ? file.path : `${remotePath}/${file.name}`
+      const subFiles = await downloadSkillDir(source, subPath, token)
       for (const subFile of subFiles) {
         if (subFile.type === 'file' && subFile.download_url) {
           const content = await downloadFile(subFile.download_url, token)

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -23,6 +23,13 @@ export interface RemoteSkill {
   path: string
 }
 
+/** A skill discovered inside a source repo */
+export interface DiscoveredSkill {
+  name: string
+  meta: SkillMeta
+  path: string
+}
+
 /** A locally installed skill */
 export interface InstalledSkill {
   name: string

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ export type {
   SourceEntry,
   TapSource,
   SkillMeta,
+  DiscoveredSkill,
   RemoteSkill,
   InstalledSkill,
 } from './core/types.js'

--- a/tests/cli/version.test.ts
+++ b/tests/cli/version.test.ts
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest'
+
+import { getCliVersion } from '../../src/cli/version.js'
+
+describe('getCliVersion', () => {
+  it('reads the CLI version from package.json', async () => {
+    await expect(getCliVersion()).resolves.toBe('0.5.0')
+  })
+})

--- a/tests/core/client.test.ts
+++ b/tests/core/client.test.ts
@@ -19,9 +19,7 @@ vi.mock('../../src/core/github.js', () => ({
     if (typeof entry !== 'string' && entry.token) return entry.token
     return globalToken
   }),
-  listRepoDirs: vi.fn().mockResolvedValue([]),
-  getSkillMd: vi.fn().mockResolvedValue(null),
-  parseFrontmatter: vi.fn().mockReturnValue(null),
+  findSkills: vi.fn().mockResolvedValue([]),
 }))
 
 vi.mock('../../src/core/agents.js', () => ({
@@ -40,7 +38,7 @@ vi.mock('../../src/core/installer.js', () => ({
 }))
 
 import { Skilltap } from '../../src/core/client.js'
-import { listRepoDirs, getSkillMd, parseFrontmatter } from '../../src/core/github.js'
+import { findSkills } from '../../src/core/github.js'
 import { installSkill, uninstallSkill, listInstalled } from '../../src/core/installer.js'
 import { resolveAgentDirs } from '../../src/core/agents.js'
 
@@ -64,34 +62,24 @@ describe('constructor', () => {
 
 describe('available', () => {
   it('aggregates skills from multiple sources', async () => {
-    vi.mocked(listRepoDirs).mockResolvedValue(['pdf', 'xlsx'])
-    vi.mocked(getSkillMd).mockResolvedValue('---\nname: pdf\ndescription: test\n---')
-    vi.mocked(parseFrontmatter).mockReturnValue({ name: 'pdf', description: 'test' })
+    vi.mocked(findSkills)
+      .mockResolvedValueOnce([
+        { name: 'pdf', path: 'skills/pdf', meta: { name: 'pdf', description: 'PDF' } },
+        { name: 'xlsx', path: 'skills/xlsx', meta: { name: 'xlsx', description: 'Excel' } },
+      ])
+      .mockResolvedValueOnce([
+        { name: 'browser', path: 'browser', meta: { name: 'browser', description: 'Browser' } },
+      ])
 
     const st = new Skilltap({ sources: ['org1/skills', 'org2/skills'] })
     const skills = await st.available()
 
-    // 2 sources × 2 dirs each = 4 skills
-    expect(skills).toHaveLength(4)
+    expect(skills).toHaveLength(3)
+    expect(skills[0].path).toBe('skills/pdf')
   })
 
-  it('skips directories without SKILL.md', async () => {
-    vi.mocked(listRepoDirs).mockResolvedValue(['pdf', 'no-skill'])
-    vi.mocked(getSkillMd)
-      .mockResolvedValueOnce('---\nname: pdf\ndescription: PDF\n---')
-      .mockResolvedValueOnce(null)
-    vi.mocked(parseFrontmatter).mockReturnValue({ name: 'pdf', description: 'PDF' })
-
-    const st = new Skilltap({ sources: ['test/skills'] })
-    const skills = await st.available()
-
-    expect(skills).toHaveLength(1)
-  })
-
-  it('skips directories with invalid frontmatter', async () => {
-    vi.mocked(listRepoDirs).mockResolvedValue(['bad'])
-    vi.mocked(getSkillMd).mockResolvedValue('no frontmatter')
-    vi.mocked(parseFrontmatter).mockReturnValue(null)
+  it('returns empty when a source has no discovered skills', async () => {
+    vi.mocked(findSkills).mockResolvedValue([])
 
     const st = new Skilltap({ sources: ['test/skills'] })
     const skills = await st.available()
@@ -111,12 +99,11 @@ describe('available', () => {
 
 describe('search', () => {
   const setupAvailable = () => {
-    vi.mocked(listRepoDirs).mockResolvedValue(['pdf', 'xlsx', 'browser'])
-    vi.mocked(getSkillMd).mockResolvedValue('content')
-    vi.mocked(parseFrontmatter)
-      .mockReturnValueOnce({ name: 'pdf', description: 'Read PDF files' })
-      .mockReturnValueOnce({ name: 'xlsx', description: 'Read Excel spreadsheets' })
-      .mockReturnValueOnce({ name: 'browser', description: 'Browser automation' })
+    vi.mocked(findSkills).mockResolvedValue([
+      { name: 'pdf', path: 'skills/pdf', meta: { name: 'pdf', description: 'Read PDF files' } },
+      { name: 'xlsx', path: 'skills/xlsx', meta: { name: 'xlsx', description: 'Read Excel spreadsheets' } },
+      { name: 'browser', path: 'browser', meta: { name: 'browser', description: 'Browser automation' } },
+    ])
   }
 
   it('matches by name (case-insensitive)', async () => {
@@ -157,10 +144,12 @@ describe('search', () => {
 // --- install ---
 
 describe('install', () => {
-  it('installs from the first source that has the skill', async () => {
-    vi.mocked(getSkillMd)
-      .mockResolvedValueOnce(null)            // source 1 doesn't have it
-      .mockResolvedValueOnce('skill content')  // source 2 has it
+  it('installs from the first source that has the skill and passes the nested path through', async () => {
+    vi.mocked(findSkills)
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        { name: 'pdf', path: 'skills/pdf', meta: { name: 'pdf', description: 'PDF skill' } },
+      ])
     vi.mocked(installSkill).mockResolvedValue({
       name: 'pdf',
       meta: { name: 'pdf', description: 'PDF skill' },
@@ -173,12 +162,12 @@ describe('install', () => {
 
     expect(result.name).toBe('pdf')
     expect(installSkill).toHaveBeenCalledWith(
-      { owner: 'org2', repo: 'skills' }, 'pdf', undefined, undefined, undefined,
+      { owner: 'org2', repo: 'skills' }, 'pdf', undefined, undefined, undefined, 'skills/pdf',
     )
   })
 
   it('throws when skill not found in any source', async () => {
-    vi.mocked(getSkillMd).mockResolvedValue(null)
+    vi.mocked(findSkills).mockResolvedValue([])
 
     const st = new Skilltap({ sources: ['test/skills'] })
 
@@ -186,7 +175,9 @@ describe('install', () => {
   })
 
   it('throws SkillConflictError when multiple sources have the same skill', async () => {
-    vi.mocked(getSkillMd).mockResolvedValue('skill content') // both sources have it
+    vi.mocked(findSkills).mockResolvedValue([
+      { name: 'pdf', path: 'skills/pdf', meta: { name: 'pdf', description: 'PDF skill' } },
+    ])
 
     const st = new Skilltap({ sources: ['org1/skills', 'org2/skills'] })
 
@@ -196,6 +187,9 @@ describe('install', () => {
   })
 
   it('installs from specified source with { from } option', async () => {
+    vi.mocked(findSkills).mockResolvedValue([
+      { name: 'pdf', path: 'skills/pdf', meta: { name: 'pdf', description: 'PDF skill' } },
+    ])
     vi.mocked(installSkill).mockResolvedValue({
       name: 'pdf',
       meta: { name: 'pdf', description: 'PDF skill' },
@@ -208,10 +202,8 @@ describe('install', () => {
 
     expect(result.name).toBe('pdf')
     expect(installSkill).toHaveBeenCalledWith(
-      { owner: 'org2', repo: 'skills' }, 'pdf', undefined, undefined, undefined,
+      { owner: 'org2', repo: 'skills' }, 'pdf', undefined, undefined, undefined, 'skills/pdf',
     )
-    // getSkillMd should NOT be called — skips conflict detection
-    expect(getSkillMd).not.toHaveBeenCalled()
   })
 })
 
@@ -245,7 +237,10 @@ describe('update', () => {
       { name: 'pdf', meta: { name: 'pdf', description: '' }, path: '/skills/pdf' },
       { name: 'xlsx', meta: { name: 'xlsx', description: '' }, path: '/skills/xlsx' },
     ])
-    vi.mocked(getSkillMd).mockResolvedValue('content')
+    vi.mocked(findSkills).mockResolvedValue([
+      { name: 'pdf', path: 'skills/pdf', meta: { name: 'pdf', description: '' } },
+      { name: 'xlsx', path: 'skills/xlsx', meta: { name: 'xlsx', description: '' } },
+    ])
 
     const st = new Skilltap({ sources: ['test/skills'] })
     const updated = await st.update()
@@ -258,7 +253,7 @@ describe('update', () => {
       { name: 'pdf', meta: { name: 'pdf', description: '' }, path: '/skills/pdf' },
       { name: 'broken', meta: { name: 'broken', description: '' }, path: '/skills/broken' },
     ])
-    vi.mocked(getSkillMd).mockResolvedValue(null)  // all sources return null → install throws
+    vi.mocked(findSkills).mockResolvedValue([])
 
     const st = new Skilltap({ sources: ['test/skills'] })
     const updated = await st.update()
@@ -280,7 +275,9 @@ describe('update', () => {
 
 describe('agents config', () => {
   it('passes resolved agent dirs as symlinkDirs to installSkill', async () => {
-    vi.mocked(getSkillMd).mockResolvedValue('content')
+    vi.mocked(findSkills).mockResolvedValue([
+      { name: 'pdf', path: 'skills/pdf', meta: { name: 'pdf', description: 'PDF skill' } },
+    ])
 
     const st = new Skilltap({ sources: ['test/skills'], agents: ['claude-code', 'cursor'] })
     await st.install('pdf')
@@ -289,6 +286,7 @@ describe('agents config', () => {
     expect(installSkill).toHaveBeenCalledWith(
       expect.anything(), 'pdf', undefined, undefined,
       ['/mock-home/.claude-code/skills', '/mock-home/.cursor/skills'],
+      'skills/pdf',
     )
   })
 
@@ -302,31 +300,37 @@ describe('agents config', () => {
   })
 
   it('does not pass symlinkDirs when no agents configured', async () => {
-    vi.mocked(getSkillMd).mockResolvedValue('content')
+    vi.mocked(findSkills).mockResolvedValue([
+      { name: 'pdf', path: 'skills/pdf', meta: { name: 'pdf', description: 'PDF skill' } },
+    ])
 
     const st = new Skilltap({ sources: ['test/skills'] })
     await st.install('pdf')
 
     expect(installSkill).toHaveBeenCalledWith(
-      expect.anything(), 'pdf', undefined, undefined, undefined,
+      expect.anything(), 'pdf', undefined, undefined, undefined, 'skills/pdf',
     )
   })
 })
 
 describe('dirs config', () => {
   it('passes custom dirs as symlinkDirs', async () => {
-    vi.mocked(getSkillMd).mockResolvedValue('content')
+    vi.mocked(findSkills).mockResolvedValue([
+      { name: 'pdf', path: 'skills/pdf', meta: { name: 'pdf', description: 'PDF skill' } },
+    ])
 
     const st = new Skilltap({ sources: ['test/skills'], dirs: ['/custom/skills'] })
     await st.install('pdf')
 
     expect(installSkill).toHaveBeenCalledWith(
-      expect.anything(), 'pdf', undefined, undefined, ['/custom/skills'],
+      expect.anything(), 'pdf', undefined, undefined, ['/custom/skills'], 'skills/pdf',
     )
   })
 
   it('merges agents and dirs, deduplicates', async () => {
-    vi.mocked(getSkillMd).mockResolvedValue('content')
+    vi.mocked(findSkills).mockResolvedValue([
+      { name: 'pdf', path: 'skills/pdf', meta: { name: 'pdf', description: 'PDF skill' } },
+    ])
 
     const st = new Skilltap({
       sources: ['test/skills'],
@@ -339,6 +343,7 @@ describe('dirs config', () => {
     expect(installSkill).toHaveBeenCalledWith(
       expect.anything(), 'pdf', undefined, undefined,
       ['/mock-home/.cursor/skills', '/extra/skills'],
+      'skills/pdf',
     )
   })
 })
@@ -347,7 +352,9 @@ describe('dirs config', () => {
 
 describe('per-source token', () => {
   it('uses per-source token when source has its own token', async () => {
-    vi.mocked(getSkillMd).mockResolvedValue('content')
+    vi.mocked(findSkills).mockResolvedValue([
+      { name: 'pdf', path: 'skills/pdf', meta: { name: 'pdf', description: 'PDF skill' } },
+    ])
 
     const st = new Skilltap({
       sources: [{ repo: 'company/private', token: 'ghp_source' }],
@@ -357,12 +364,14 @@ describe('per-source token', () => {
 
     // Per-source token should be passed (not global)
     expect(installSkill).toHaveBeenCalledWith(
-      { owner: 'company', repo: 'private' }, 'pdf', undefined, 'ghp_source', undefined,
+      { owner: 'company', repo: 'private' }, 'pdf', undefined, 'ghp_source', undefined, 'skills/pdf',
     )
   })
 
   it('falls back to global token when source has no token', async () => {
-    vi.mocked(getSkillMd).mockResolvedValue('content')
+    vi.mocked(findSkills).mockResolvedValue([
+      { name: 'pdf', path: 'skills/pdf', meta: { name: 'pdf', description: 'PDF skill' } },
+    ])
 
     const st = new Skilltap({
       sources: ['company/public'],
@@ -371,25 +380,27 @@ describe('per-source token', () => {
     await st.install('pdf')
 
     expect(installSkill).toHaveBeenCalledWith(
-      { owner: 'company', repo: 'public' }, 'pdf', undefined, 'ghp_global', undefined,
+      { owner: 'company', repo: 'public' }, 'pdf', undefined, 'ghp_global', undefined, 'skills/pdf',
     )
   })
 
   it('passes undefined token when neither source nor global token set', async () => {
-    vi.mocked(getSkillMd).mockResolvedValue('content')
+    vi.mocked(findSkills).mockResolvedValue([
+      { name: 'pdf', path: 'skills/pdf', meta: { name: 'pdf', description: 'PDF skill' } },
+    ])
 
     const st = new Skilltap({ sources: ['public/repo'] })
     await st.install('pdf')
 
     expect(installSkill).toHaveBeenCalledWith(
-      { owner: 'public', repo: 'repo' }, 'pdf', undefined, undefined, undefined,
+      { owner: 'public', repo: 'repo' }, 'pdf', undefined, undefined, undefined, 'skills/pdf',
     )
   })
 
   it('uses per-source token for available() API calls', async () => {
-    vi.mocked(listRepoDirs).mockResolvedValue(['pdf'])
-    vi.mocked(getSkillMd).mockResolvedValue('---\nname: pdf\ndescription: test\n---')
-    vi.mocked(parseFrontmatter).mockReturnValue({ name: 'pdf', description: 'test' })
+    vi.mocked(findSkills).mockResolvedValue([
+      { name: 'pdf', path: 'skills/pdf', meta: { name: 'pdf', description: 'test' } },
+    ])
 
     const st = new Skilltap({
       sources: [{ repo: 'company/private', token: 'ghp_source' }],
@@ -397,15 +408,13 @@ describe('per-source token', () => {
     })
     await st.available()
 
-    // Per-source token should be passed to listRepoDirs and getSkillMd
-    expect(listRepoDirs).toHaveBeenCalledWith({ owner: 'company', repo: 'private' }, 'ghp_source')
-    expect(getSkillMd).toHaveBeenCalledWith({ owner: 'company', repo: 'private' }, 'pdf', 'ghp_source')
+    expect(findSkills).toHaveBeenCalledWith({ owner: 'company', repo: 'private' }, 'ghp_source')
   })
 
   it('handles mixed string and SourceConfig sources', async () => {
-    vi.mocked(listRepoDirs).mockResolvedValue(['pdf'])
-    vi.mocked(getSkillMd).mockResolvedValue('---\nname: pdf\ndescription: test\n---')
-    vi.mocked(parseFrontmatter).mockReturnValue({ name: 'pdf', description: 'test' })
+    vi.mocked(findSkills).mockResolvedValue([
+      { name: 'pdf', path: 'skills/pdf', meta: { name: 'pdf', description: 'test' } },
+    ])
 
     const st = new Skilltap({
       sources: ['public/repo', { repo: 'company/private', token: 'ghp_private' }],
@@ -413,10 +422,8 @@ describe('per-source token', () => {
     })
     await st.available()
 
-    // First source (string) uses global token
-    expect(listRepoDirs).toHaveBeenCalledWith({ owner: 'public', repo: 'repo' }, 'ghp_global')
-    // Second source (SourceConfig) uses per-source token
-    expect(listRepoDirs).toHaveBeenCalledWith({ owner: 'company', repo: 'private' }, 'ghp_private')
+    expect(findSkills).toHaveBeenNthCalledWith(1, { owner: 'public', repo: 'repo' }, 'ghp_global')
+    expect(findSkills).toHaveBeenNthCalledWith(2, { owner: 'company', repo: 'private' }, 'ghp_private')
   })
 
   it('accepts SourceConfig in constructor without error', () => {
@@ -430,6 +437,9 @@ describe('per-source token', () => {
   })
 
   it('resolves per-source token for install with --from matching a SourceConfig', async () => {
+    vi.mocked(findSkills).mockResolvedValue([
+      { name: 'pdf', path: 'skills/pdf', meta: { name: 'pdf', description: 'PDF skill' } },
+    ])
     vi.mocked(installSkill).mockResolvedValue({
       name: 'pdf',
       meta: { name: 'pdf', description: 'PDF skill' },
@@ -444,7 +454,7 @@ describe('per-source token', () => {
     await st.install('pdf', { from: 'company/private' })
 
     expect(installSkill).toHaveBeenCalledWith(
-      { owner: 'company', repo: 'private' }, 'pdf', undefined, 'ghp_private', undefined,
+      { owner: 'company', repo: 'private' }, 'pdf', undefined, 'ghp_private', undefined, 'skills/pdf',
     )
   })
 })

--- a/tests/core/github.test.ts
+++ b/tests/core/github.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { parseSource, parseSourceEntry, sourceEntryRepo, resolveToken, listRepoDirs, getSkillMd, downloadSkillDir, downloadFile, parseFrontmatter } from '../../src/core/github.js'
+import { parseSource, parseSourceEntry, sourceEntryRepo, resolveToken, listRepoDirs, getSkillMd, downloadSkillDir, downloadFile, parseFrontmatter, findSkills } from '../../src/core/github.js'
 import {
   VALID_SKILL_MD,
   MINIMAL_SKILL_MD,
@@ -255,6 +255,90 @@ describe('downloadSkillDir', () => {
     }))
 
     await expect(downloadSkillDir(source, 'pdf')).rejects.toThrow('404')
+  })
+})
+
+// --- findSkills ---
+
+describe('findSkills', () => {
+  const source = { owner: 'test', repo: 'skills' }
+
+  it('finds skills recursively from nested directories', async () => {
+    vi.stubGlobal('fetch', mockFetchResponses({
+      'contents/template/SKILL.md': {
+        status: 200,
+        body: `---\nname: template\ndescription: Template skill\n---`,
+      },
+      'contents/skills/SKILL.md': { status: 404, body: 'Not Found' },
+      'contents/skills/pdf/SKILL.md': {
+        status: 200,
+        body: `---\nname: pdf\ndescription: Read PDF files\n---`,
+      },
+      'contents/skills/docx/SKILL.md': {
+        status: 200,
+        body: `---\nname: docx\ndescription: Read Word files\n---`,
+      },
+      'contents/skills': {
+        status: 200,
+        body: makeRepoContents(['pdf', 'docx']),
+      },
+      'contents/docs/SKILL.md': { status: 404, body: 'Not Found' },
+      'contents/docs': {
+        status: 200,
+        body: [],
+      },
+      'contents/': {
+        status: 200,
+        body: makeRepoContents(['template', 'skills', 'docs'], ['README.md']),
+      },
+    }))
+
+    const skills = await findSkills(source)
+
+    expect(skills).toEqual([
+      {
+        name: 'template',
+        path: 'template',
+        meta: { name: 'template', description: 'Template skill' },
+      },
+      {
+        name: 'pdf',
+        path: 'skills/pdf',
+        meta: { name: 'pdf', description: 'Read PDF files' },
+      },
+      {
+        name: 'docx',
+        path: 'skills/docx',
+        meta: { name: 'docx', description: 'Read Word files' },
+      },
+    ])
+  })
+
+  it('stops descending once a directory is identified as a skill', async () => {
+    const mockFetch = vi.fn(mockFetchResponses({
+      'contents/bundle/SKILL.md': {
+        status: 200,
+        body: `---\nname: bundle\ndescription: Parent skill\n---`,
+      },
+      'contents/': {
+        status: 200,
+        body: makeRepoContents(['bundle']),
+      },
+    }))
+    vi.stubGlobal('fetch', mockFetch as unknown as typeof fetch)
+
+    const skills = await findSkills(source)
+
+    expect(skills).toEqual([
+      {
+        name: 'bundle',
+        path: 'bundle',
+        meta: { name: 'bundle', description: 'Parent skill' },
+      },
+    ])
+    expect(
+      mockFetch.mock.calls.some(([url]) => String(url).includes('contents/bundle/scripts')),
+    ).toBe(false)
   })
 })
 

--- a/tests/core/installer.test.ts
+++ b/tests/core/installer.test.ts
@@ -76,6 +76,20 @@ describe('installSkill', () => {
     expect(downloadSkillDir).toHaveBeenCalledTimes(2)
   })
 
+  it('downloads a nested remote skill path into a flat local skill directory', async () => {
+    const files = [makeGitHubFile('SKILL.md', 'https://example.com/SKILL.md')]
+    vi.mocked(downloadSkillDir).mockResolvedValue(files)
+    vi.mocked(downloadFile).mockResolvedValue(VALID_SKILL_MD)
+    vi.mocked(fs.readFile).mockResolvedValue(VALID_SKILL_MD)
+    vi.mocked(parseFrontmatter).mockReturnValue({ name: 'pdf', description: 'PDF skill' })
+
+    const result = await installSkill(source, 'pdf', '/install-dir', undefined, undefined, 'skills/pdf')
+
+    expect(downloadSkillDir).toHaveBeenCalledWith(source, 'skills/pdf', undefined)
+    expect(fs.mkdir).toHaveBeenCalledWith('/install-dir/pdf', { recursive: true })
+    expect(result.path).toBe('/install-dir/pdf')
+  })
+
   it('skips files with null download_url', async () => {
     const files = [{ name: 'ghost.md', path: 'ghost.md', type: 'file' as const, download_url: null }]
     vi.mocked(downloadSkillDir).mockResolvedValue(files)

--- a/tests/e2e/live-github.test.ts
+++ b/tests/e2e/live-github.test.ts
@@ -3,12 +3,12 @@ import fs from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
 
-import { parseSource, listRepoDirs, getSkillMd } from '../../src/core/github.js'
+import { parseSource, listRepoDirs, getSkillMd, findSkills } from '../../src/core/github.js'
 import { installSkill, listInstalled, uninstallSkill } from '../../src/core/installer.js'
 import { Skilltap } from '../../src/core/client.js'
 
-// Only run when SKILLTAP_E2E is set
-const SKIP = !process.env.SKILLTAP_E2E
+// Only run when explicitly enabled with a token to avoid GitHub API rate limits.
+const SKIP = !process.env.SKILLTAP_E2E || !process.env.GITHUB_TOKEN
 
 let tmpDir: string
 
@@ -28,15 +28,22 @@ const source = parseSource(TEST_REPO)
 const token = process.env.GITHUB_TOKEN
 
 describe.skipIf(SKIP)('E2E: real GitHub API', () => {
-  it('listRepoDirs returns skill directories', async () => {
+  it('listRepoDirs returns top-level directories from the tap root', async () => {
     const dirs = await listRepoDirs(source, token)
 
     expect(dirs.length).toBeGreaterThan(0)
-    expect(dirs).toContain('pdf')
+    expect(dirs).toContain('skills')
   })
 
+  it('findSkills discovers nested skills recursively', async () => {
+    const skills = await findSkills(source, token)
+
+    expect(skills.length).toBeGreaterThan(0)
+    expect(skills.find((skill) => skill.name === 'pdf')?.path).toBe('skills/pdf')
+  }, 15_000)
+
   it('getSkillMd returns content for existing skill', async () => {
-    const content = await getSkillMd(source, 'pdf', token)
+    const content = await getSkillMd(source, 'skills/pdf', token)
 
     expect(content).not.toBeNull()
     expect(content).toContain('name:')
@@ -49,7 +56,7 @@ describe.skipIf(SKIP)('E2E: real GitHub API', () => {
   })
 
   it('installs a skill to temp directory', async () => {
-    const result = await installSkill(source, 'pdf', tmpDir, token)
+    const result = await installSkill(source, 'pdf', tmpDir, token, undefined, 'skills/pdf')
 
     expect(result.name).toBe('pdf')
     expect(result.path).toBe(path.join(tmpDir, 'pdf'))
@@ -85,6 +92,7 @@ describe.skipIf(SKIP)('E2E: full Skilltap client flow', () => {
     // available
     const available = await st.available()
     expect(available.length).toBeGreaterThan(0)
+    expect(available.find((skill) => skill.name === 'pdf')?.path).toBe('skills/pdf')
 
     // install
     const installed = await st.install('pdf')

--- a/vitest.e2e.config.ts
+++ b/vitest.e2e.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    globals: true,
+    include: ['tests/e2e/**/*.test.ts'],
+    mockReset: true,
+    testTimeout: 30_000,
+  },
+})


### PR DESCRIPTION
## Summary
- read the CLI version from package.json
- discover skills recursively by locating SKILL.md in nested directories
- update installer, tests, docs, and e2e config for nested skill paths

## Verification
- pnpm test
- pnpm build