### PR TITLE
feat: add marketplace support for browsing and installing skills

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -6,6 +6,14 @@ import { getCliVersion } from './version.js'
 import { SkillConflictError } from '../core/types.js'
 import type { SkilltapConfigFile, SourceEntry } from '../core/types.js'
 import { sourceEntryRepo } from '../core/github.js'
+import {
+  createMarketplaceCommands,
+  createBrowseCommand,
+  createSearchCommand,
+  createInstallCommand,
+  createUninstallCommand,
+  createListCommand,
+} from './marketplace.js'
 
 const program = new Command()
 
@@ -57,105 +65,6 @@ program
   })
 
 program
-  .command('search <keyword>')
-  .description('Search for skills across all sources')
-  .action(async (keyword: string) => {
-    const config = await loadConfig()
-    const st = new Skilltap(config)
-    const results = await st.search(keyword)
-
-    if (results.length === 0) {
-      console.log('No skills found')
-      return
-    }
-
-    for (const skill of results) {
-      const source = `${skill.source.owner}/${skill.source.repo}`
-      console.log(`  ${skill.name} — ${skill.meta.description} (${source})`)
-    }
-  })
-
-program
-  .command('install <name>')
-  .description('Install a skill')
-  .option('-g, --global', 'Symlink to all detected agents')
-  .option('-a, --agent <ids...>', 'Symlink to specific agent(s) (e.g. claude-code cursor)')
-  .option('-d, --dir <paths...>', 'Symlink to custom directory(s)')
-  .option('--from <source>', 'Install from a specific source (e.g. anthropics/skills)')
-  .action(async (name: string, opts: { global?: boolean; agent?: string[]; dir?: string[]; from?: string }) => {
-    const config = await loadConfig()
-    await resolveAgentOpts(config, opts)
-
-    const st = new Skilltap(config)
-
-    try {
-      const skill = await st.install(name, { from: opts.from })
-      console.log(`Installed: ${skill.name} → ${skill.path}`)
-
-      // Show symlink results
-      const allDirs: string[] = []
-      if (config.agents?.length) allDirs.push(...resolveAgentDirs(config.agents))
-      if (config.dirs?.length) allDirs.push(...config.dirs)
-      const linked = allDirs.filter((d) => d !== config.installDir)
-
-      if (linked.length > 0) {
-        console.log(`Symlinked to ${linked.length} target(s):`)
-        for (const dir of linked) {
-          console.log(`  → ${dir}/${name}`)
-        }
-      } else {
-        console.log('')
-        console.log('Tip: use -g to symlink to all agents, or -a to pick specific ones:')
-        console.log('  skilltap install <name> -g')
-        console.log('  skilltap install <name> -a claude-code cursor')
-      }
-    } catch (err) {
-      if (err instanceof SkillConflictError) {
-        console.error(`Multiple skills found for "${name}":`)
-        for (const source of err.sources) {
-          console.error(`  - ${source}`)
-        }
-        console.error(`\nUse --from to specify: skilltap install ${name} --from <owner/repo>`)
-        process.exit(1)
-      }
-      throw err
-    }
-  })
-
-program
-  .command('uninstall <name>')
-  .description('Uninstall a skill')
-  .option('-g, --global', 'Remove symlinks from all detected agents')
-  .option('-a, --agent <ids...>', 'Remove symlinks from specific agent(s)')
-  .option('-d, --dir <paths...>', 'Remove symlinks from custom directory(s)')
-  .action(async (name: string, opts: { global?: boolean; agent?: string[]; dir?: string[] }) => {
-    const config = await loadConfig()
-    await resolveAgentOpts(config, opts)
-
-    const st = new Skilltap(config)
-    await st.uninstall(name)
-    console.log(`Uninstalled: ${name}`)
-  })
-
-program
-  .command('list')
-  .description('List installed skills')
-  .action(async () => {
-    const config = await loadConfig()
-    const st = new Skilltap(config)
-    const skills = await st.list()
-
-    if (skills.length === 0) {
-      console.log('No skills installed')
-      return
-    }
-
-    for (const skill of skills) {
-      console.log(`  ${skill.name} — ${skill.meta.description}`)
-    }
-  })
-
-program
   .command('update')
   .description('Update all installed skills')
   .option('-g, --global', 'Also update symlinks for all detected agents')
@@ -200,5 +109,13 @@ program
 
     console.log(`\n  ${detected.length} agent(s) detected`)
   })
+
+// Marketplace commands
+createMarketplaceCommands(program)
+createBrowseCommand(program)
+createSearchCommand(program)
+createInstallCommand(program)
+createUninstallCommand(program)
+createListCommand(program)
 
 program.parse()

--- a/src/cli/marketplace.ts
+++ b/src/cli/marketplace.ts
@@ -1,0 +1,362 @@
+/**
+ * Marketplace CLI commands for skilltap
+ * 
+ * Provides commands for managing marketplaces and browsing skills.
+ */
+
+import { Command } from 'commander'
+import { listMarketplaces, addMarketplace, removeMarketplace, getMarketplaceManifest } from '../core/marketplace/manager.js'
+import { search, installFromMarketplace, uninstallFromMarketplace, listInstalledWithMarketplace } from '../core/marketplace/operations.js'
+import { parseSkillIdentifier } from '../core/marketplace/types.js'
+
+/** Create marketplace commands */
+export function createMarketplaceCommands(program: Command): void {
+  const marketplace = program
+    .command('marketplace')
+    .description('Manage skill marketplaces')
+
+  marketplace
+    .command('list')
+    .description('List configured marketplaces')
+    .action(async () => {
+      const marketplaces = await listMarketplaces()
+      
+      if (marketplaces.length === 0) {
+        console.log('No marketplaces configured.')
+        console.log('Run: skilltap marketplace add <name> <source>')
+        return
+      }
+      
+      console.log(`Configured marketplaces (${marketplaces.length}):\n`)
+      for (const mkt of marketplaces) {
+        const source = mkt.type === 'github' ? mkt.repo : mkt.type === 'url' ? mkt.url : mkt.path
+        console.log(`  ${mkt.name}`)
+        console.log(`    Type: ${mkt.type}`)
+        console.log(`    Source: ${source}`)
+        console.log(`    Added: ${new Date(mkt.addedAt).toLocaleDateString()}`)
+        console.log('')
+      }
+    })
+
+  marketplace
+    .command('add <name> <source>')
+    .description('Add a marketplace (e.g., skilltap marketplace add myskills github/anthropics/skills)')
+    .option('-b, --branch <branch>', 'Branch for GitHub repos')
+    .action(async (name: string, source: string, opts: { branch?: string }) => {
+      try {
+        // Parse source format: github/owner/repo, url/http://..., or local/path
+        if (source.startsWith('http://') || source.startsWith('https://')) {
+          await addMarketplace(name, 'url', { url: source })
+          console.log(`Added marketplace "${name}" from URL: ${source}`)
+        } else if (source.startsWith('/') || source.startsWith('.') || source.match(/^[A-Za-z]:/)) {
+          // Local path (absolute or relative)
+          await addMarketplace(name, 'local', { path: source })
+          console.log(`Added marketplace "${name}" from local path: ${source}`)
+        } else if (source.startsWith('github/')) {
+          // github/owner/repo format
+          const repo = source.slice('github/'.length)
+          await addMarketplace(name, 'github', { repo, branch: opts.branch })
+          console.log(`Added marketplace "${name}" from GitHub: ${repo}`)
+        } else if (source.includes('/') && source.split('/').length === 2) {
+          // owner/repo format (exactly 2 parts)
+          await addMarketplace(name, 'github', { repo: source, branch: opts.branch })
+          console.log(`Added marketplace "${name}" from GitHub: ${source}`)
+        } else {
+          console.error(`Invalid source format: ${source}`)
+          console.error('Examples:')
+          console.error('  github/owner/repo  - GitHub repo with prefix')
+          console.error('  owner/repo        - GitHub repo (owner/name format)')
+          console.error('  https://...       - URL source')
+          console.error('  /path/to/dir     - Local directory')
+          process.exit(1)
+        }
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error)
+        console.error(`Failed to add marketplace: ${msg}`)
+        process.exit(1)
+      }
+    })
+
+  marketplace
+    .command('remove <name>')
+    .description('Remove a marketplace')
+    .action(async (name: string) => {
+      try {
+        await removeMarketplace(name)
+        console.log(`Removed marketplace "${name}"`)
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error)
+        console.error(`Failed to remove marketplace: ${msg}`)
+        process.exit(1)
+      }
+    })
+
+  marketplace
+    .command('refresh [name]')
+    .description('Refresh marketplace cache (all or specific marketplace)')
+    .action(async (name?: string) => {
+      try {
+        if (name) {
+          console.log(`Refreshing marketplace "${name}"...`)
+          const manifest = await getMarketplaceManifest(name, true)
+          if (manifest) {
+            console.log(`Found ${manifest.skills.length} skills in "${name}"`)
+          } else {
+            console.log(`Marketplace "${name}" not found`)
+          }
+        } else {
+          console.log('Refreshing all marketplaces...')
+          const marketplaces = await listMarketplaces()
+          for (const mkt of marketplaces) {
+            const manifest = await getMarketplaceManifest(mkt.name, true)
+            console.log(`  ${mkt.name}: ${manifest?.skills.length ?? 0} skills`)
+          }
+        }
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error)
+        console.error(`Failed to refresh marketplace: ${msg}`)
+        process.exit(1)
+      }
+    })
+}
+
+/** Create browse command for interactive marketplace browsing */
+export function createBrowseCommand(program: Command): void {
+  program
+    .command('browse [marketplace]')
+    .description('Browse skills in marketplace (interactive selection)')
+    .option('-m, --marketplace <name>', 'Specific marketplace to browse')
+    .action(async (marketplace?: string, opts?: { marketplace?: string }) => {
+      const targetMarketplace = marketplace ?? opts?.marketplace
+      
+      if (targetMarketplace) {
+        await browseMarketplace(targetMarketplace)
+      } else {
+        await browseAllMarketplaces()
+      }
+    })
+}
+
+/** Browse a specific marketplace */
+async function browseMarketplace(name: string): Promise<void> {
+  const manifest = await getMarketplaceManifest(name)
+  
+  if (!manifest) {
+    console.error(`Marketplace "${name}" not found`)
+    process.exit(1)
+  }
+  
+  console.log(`\n=== Marketplace: ${name} ===`)
+  console.log(`Skills found: ${manifest.skills.length}\n`)
+  
+  if (manifest.skills.length === 0) {
+    console.log('No skills found. Try refreshing the marketplace:')
+    console.log(`  skilltap marketplace refresh ${name}`)
+    return
+  }
+  
+  // List skills
+  for (const skill of manifest.skills) {
+    console.log(`  ${skill.name}`)
+    console.log(`    ${skill.description || 'No description'}`)
+    if (skill.author) console.log(`    Author: ${skill.author}`)
+    if (skill.version) console.log(`    Version: ${skill.version}`)
+    console.log('')
+  }
+  
+  console.log('Install a skill:')
+  console.log(`  skilltap install <skill-name> --marketplace ${name}`)
+}
+
+/** Browse all marketplaces */
+async function browseAllMarketplaces(): Promise<void> {
+  const marketplaces = await listMarketplaces()
+  
+  if (marketplaces.length === 0) {
+    console.log('No marketplaces configured.')
+    console.log('\nAdd a marketplace first:')
+    console.log('  skilltap marketplace add myskills github/owner/skills-repo')
+    console.log('  skilltap marketplace add local /path/to/skills')
+    return
+  }
+  
+  console.log(`\n=== Available Marketplaces (${marketplaces.length}) ===\n`)
+  
+  for (const mkt of marketplaces) {
+    const manifest = await getMarketplaceManifest(mkt.name)
+    const skillCount = manifest?.skills.length ?? 0
+    const source = mkt.type === 'github' ? mkt.repo : mkt.type === 'url' ? mkt.url : mkt.path
+    console.log(`  ${mkt.name} (${skillCount} skills)`)
+    console.log(`    Source: ${source}`)
+    console.log('')
+  }
+  
+  console.log('Browse a specific marketplace:')
+  console.log('  skilltap browse <marketplace-name>')
+  console.log('\nOr install a skill directly:')
+  console.log('  skilltap install <skill-name>')
+}
+
+/** Create search command that uses marketplace */
+export function createSearchCommand(program: Command): void {
+  program
+    .command('search <keyword>')
+    .description('Search for skills across all marketplaces')
+    .option('-m, --marketplace <name>', 'Search in specific marketplace')
+    .action(async (keyword: string, opts: { marketplace?: string }) => {
+      const results = await search(keyword, opts.marketplace)
+      
+      if (results.length === 0) {
+        console.log(`No skills found matching "${keyword}"`)
+        if (!opts.marketplace) {
+          console.log('\nTip: Add a marketplace first:')
+          console.log('  skilltap marketplace add myskills github/owner/skills-repo')
+        }
+        return
+      }
+      
+      // Group by marketplace
+      const byMarketplace = new Map<string, typeof results>()
+      for (const result of results) {
+        const existing = byMarketplace.get(result.marketplace) ?? []
+        existing.push(result)
+        byMarketplace.set(result.marketplace, existing)
+      }
+      
+      console.log(`\nFound ${results.length} skill(s) matching "${keyword}":\n`)
+      
+      for (const [mktName, skills] of byMarketplace) {
+        console.log(`--- ${mktName} ---`)
+        for (const { skill } of skills) {
+          console.log(`  ${skill.name}`)
+          console.log(`    ${skill.description || 'No description'}`)
+          console.log('')
+        }
+      }
+      
+      console.log('Install a skill:')
+      console.log('  skilltap install <skill-name>')
+    })
+}
+
+/** Create install command that uses marketplace */
+export function createInstallCommand(program: Command): void {
+  program
+    .command('install <name>')
+    .description('Install a skill')
+    .option('-m, --marketplace <name>', 'Install from specific marketplace')
+    .option('-g, --global', 'Symlink to all detected agents')
+    .option('-a, --agent <ids...>', 'Symlink to specific agent(s)')
+    .option('-d, --dir <paths...>', 'Symlink to custom directory(s)')
+    .action(async (name: string, opts: { marketplace?: string; global?: boolean; agent?: string[]; dir?: string[] }) => {
+      // Check if this is a marketplace reference (name@marketplace)
+      const { name: skillName, marketplace: mktFromName } = parseSkillIdentifier(name)
+      const targetMarketplace = opts.marketplace ?? mktFromName
+      
+      if (targetMarketplace) {
+        // Install from marketplace
+        const result = await installFromMarketplace(
+          targetMarketplace ? `${skillName}@${targetMarketplace}` : skillName
+        )
+        
+        if (!result.success) {
+          console.error(`Failed to install: ${result.message}`)
+          process.exit(1)
+        }
+        
+        console.log(`✓ ${result.message}`)
+        if (result.path) {
+          console.log(`  Installed to: ${result.path}`)
+        }
+      } else {
+        // Try marketplace search first
+        console.log(`Searching for "${skillName}" in marketplaces...`)
+        const results = await search(skillName)
+        
+        if (results.length === 0) {
+          console.error(`Skill "${skillName}" not found in any marketplace`)
+          console.error('\nTip: Add a marketplace first:')
+          console.error('  skilltap marketplace add myskills github/owner/skills-repo')
+          process.exit(1)
+        }
+        
+        if (results.length > 1) {
+          console.error(`Multiple skills found for "${skillName}":`)
+          for (const { skill, marketplace } of results) {
+            console.error(`  - ${skill.name}@${marketplace}`)
+          }
+          console.error(`\nSpecify which marketplace to use:`)
+          console.error(`  skilltap install ${skillName} --marketplace <name>`)
+          process.exit(1)
+        }
+        
+        const { skill, marketplace } = results[0]
+        const result = await installFromMarketplace(`${skill.name}@${marketplace}`)
+        
+        if (!result.success) {
+          console.error(`Failed to install: ${result.message}`)
+          process.exit(1)
+        }
+        
+        console.log(`✓ ${result.message}`)
+        if (result.path) {
+          console.log(`  Installed to: ${result.path}`)
+        }
+      }
+    })
+}
+
+/** Create uninstall command that uses marketplace */
+export function createUninstallCommand(program: Command): void {
+  program
+    .command('uninstall <name>')
+    .description('Uninstall a skill')
+    .option('-m, --marketplace <name>', 'Uninstall from specific marketplace')
+    .action(async (name: string, opts: { marketplace?: string }) => {
+      const { name: skillName, marketplace: mktFromName } = parseSkillIdentifier(name)
+      const targetMarketplace = opts.marketplace ?? mktFromName
+      
+      const result = await uninstallFromMarketplace(skillName, targetMarketplace)
+      
+      if (!result.success) {
+        console.error(`Failed to uninstall: ${result.message}`)
+        process.exit(1)
+      }
+      
+      console.log(`✓ ${result.message}`)
+    })
+}
+
+/** Create list command that shows marketplace info */
+export function createListCommand(program: Command): void {
+  program
+    .command('list')
+    .description('List installed skills')
+    .option('-v, --verbose', 'Show verbose output with marketplace info')
+    .action(async (opts: { verbose?: boolean }) => {
+      const installed = await listInstalledWithMarketplace()
+      
+      if (installed.length === 0) {
+        console.log('No skills installed')
+        console.log('\nBrowse available skills:')
+        console.log('  skilltap browse')
+        return
+      }
+      
+      console.log(`\nInstalled skills (${installed.length}):\n`)
+      
+      if (opts.verbose) {
+        for (const skill of installed) {
+          console.log(`  ${skill.name}@${skill.marketplace}`)
+          console.log(`    Installed: ${new Date(skill.installedAt).toLocaleDateString()}`)
+          if (skill.version) console.log(`    Version: ${skill.version}`)
+          console.log(`    Path: ${skill.installPath}`)
+          console.log('')
+        }
+      } else {
+        for (const skill of installed) {
+          console.log(`  ${skill.name}@${skill.marketplace}`)
+        }
+      }
+    })
+}

--- a/src/core/marketplace/manager.ts
+++ b/src/core/marketplace/manager.ts
@@ -1,0 +1,303 @@
+/**
+ * Marketplace manager for skilltap
+ * 
+ * Manages marketplace sources, caching, and skill discovery.
+ * Inspired by claude-code's marketplace system but simplified for skills.
+ */
+
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import os from 'node:os'
+import { findSkills } from '../github.js'
+import type { 
+  Marketplace, 
+  MarketplaceConfig, 
+  MarketplaceManifest, 
+  SkillEntry,
+  MarketplaceConfigSchema 
+} from './types.js'
+import { parseSkillIdentifier } from './types.js'
+
+const CONFIG_FILE = 'marketplaces.json'
+const CACHE_DIR = 'marketplaces'
+
+/** Get the skilltap config directory */
+function getConfigDir(): string {
+  return path.join(os.homedir(), '.skilltap')
+}
+
+/** Get the config file path */
+function getConfigPath(): string {
+  return path.join(getConfigDir(), CONFIG_FILE)
+}
+
+/** Get the cache directory path */
+function getCacheDir(): string {
+  return path.join(getConfigDir(), CACHE_DIR)
+}
+
+/** Ensure config directory exists */
+async function ensureConfigDir(): Promise<void> {
+  await fs.mkdir(getConfigDir(), { recursive: true })
+  await fs.mkdir(getCacheDir(), { recursive: true })
+}
+
+/** Load marketplace config */
+export async function loadMarketplaceConfig(): Promise<MarketplaceConfig> {
+  await ensureConfigDir()
+  const configPath = getConfigPath()
+  try {
+    const content = await fs.readFile(configPath, 'utf-8')
+    return JSON.parse(content)
+  } catch {
+    return { version: '1.0', marketplaces: {} }
+  }
+}
+
+/** Save marketplace config */
+async function saveMarketplaceConfig(config: MarketplaceConfig): Promise<void> {
+  await ensureConfigDir()
+  const configPath = getConfigPath()
+  await fs.writeFile(configPath, JSON.stringify(config, null, 2), 'utf-8')
+}
+
+/** Add a marketplace */
+export async function addMarketplace(
+  name: string,
+  type: 'github' | 'url' | 'local',
+  options: { repo?: string; url?: string; path?: string; branch?: string } = {}
+): Promise<Marketplace> {
+  const config = await loadMarketplaceConfig()
+  
+  if (config.marketplaces[name]) {
+    throw new Error(`Marketplace "${name}" already exists`)
+  }
+
+  const marketplace: Marketplace = {
+    name,
+    type,
+    addedAt: new Date().toISOString(),
+    ...options,
+  }
+
+  config.marketplaces[name] = marketplace
+  await saveMarketplaceConfig(config)
+  
+  return marketplace
+}
+
+/** Remove a marketplace */
+export async function removeMarketplace(name: string): Promise<void> {
+  const config = await loadMarketplaceConfig()
+  
+  if (!config.marketplaces[name]) {
+    throw new Error(`Marketplace "${name}" not found`)
+  }
+
+  delete config.marketplaces[name]
+  await saveMarketplaceConfig(config)
+  
+  // Remove cache
+  const cachePath = path.join(getCacheDir(), `${name}.json`)
+  await fs.rm(cachePath, { force: true })
+}
+
+/** List all marketplaces */
+export async function listMarketplaces(): Promise<Marketplace[]> {
+  const config = await loadMarketplaceConfig()
+  return Object.values(config.marketplaces)
+}
+
+/** Get a specific marketplace */
+export async function getMarketplace(name: string): Promise<Marketplace | null> {
+  const config = await loadMarketplaceConfig()
+  return config.marketplaces[name] ?? null
+}
+
+/** Discover skills from a marketplace by fetching its manifest or scanning repos */
+export async function discoverSkillsFromMarketplace(
+  marketplace: Marketplace
+): Promise<SkillEntry[]> {
+  const skills: SkillEntry[] = []
+  
+  if (marketplace.type === 'github' && marketplace.repo) {
+    const [owner, repo] = marketplace.repo.split('/')
+    if (!owner || !repo) {
+      throw new Error(`Invalid marketplace repo: ${marketplace.repo}`)
+    }
+    
+    try {
+      const discovered = await findSkills(
+        { owner, repo, branch: marketplace.branch },
+        undefined, // token - could add token support later
+        '' // repo root
+      )
+      
+      for (const skill of discovered) {
+        skills.push({
+          name: skill.meta.name || skill.name,
+          description: skill.meta.description || '',
+          author: skill.meta.author,
+          version: skill.meta.version,
+          license: skill.meta.license,
+          argumentHint: skill.meta.argumentHint,
+          path: skill.path,
+          source: { owner, repo, branch: marketplace.branch },
+        })
+      }
+    } catch (error) {
+      console.error(`Failed to discover skills from ${marketplace.name}:`, error)
+    }
+  } else if (marketplace.type === 'local' && marketplace.path) {
+    // Local marketplace - scan directory for SKILL.md files
+    await scanLocalSkills(marketplace.path, skills)
+  }
+  
+  return skills
+}
+
+/** Recursively scan a local directory for skills */
+async function scanLocalSkills(dirPath: string, skills: SkillEntry[], basePath = ''): Promise<void> {
+  try {
+    const entries = await fs.readdir(dirPath, { withFileTypes: true })
+    
+    for (const entry of entries) {
+      if (!entry.isDirectory() || entry.name.startsWith('.')) continue
+      
+      const fullPath = path.join(dirPath, entry.name)
+      const skillMdPath = path.join(fullPath, 'SKILL.md')
+      
+      try {
+        const content = await fs.readFile(skillMdPath, 'utf-8')
+        const meta = parseFrontmatter(content)
+        if (meta) {
+          skills.push({
+            name: meta.name || entry.name,
+            description: meta.description || '',
+            author: meta.author,
+            version: meta.version,
+            license: meta.license,
+            argumentHint: meta.argumentHint,
+            path: basePath ? `${basePath}/${entry.name}` : entry.name,
+            source: { owner: '', repo: '' }, // Local skills don't have source
+          })
+        }
+      } catch {
+        // No SKILL.md, recurse into subdirectory
+        await scanLocalSkills(fullPath, skills, basePath ? `${basePath}/${entry.name}` : entry.name)
+      }
+    }
+  } catch {
+    // Directory doesn't exist or not readable
+  }
+}
+
+/** Parse frontmatter from SKILL.md content */
+function parseFrontmatter(content: string): Record<string, string> | null {
+  const match = content.match(/^---\n([\s\S]*?)\n---/)
+  if (!match) return null
+
+  const meta: Record<string, string> = {}
+  for (const line of match[1].split('\n')) {
+    const idx = line.indexOf(':')
+    if (idx === -1) continue
+    const key = line.slice(0, idx).trim()
+    let val = line.slice(idx + 1).trim()
+    if ((val.startsWith('"') && val.endsWith('"')) || (val.startsWith("'") && val.endsWith("'"))) {
+      val = val.slice(1, -1)
+    }
+    meta[key] = val
+  }
+  return meta.name ? meta : null
+}
+
+/** Get or cache marketplace manifest */
+export async function getMarketplaceManifest(
+  marketplaceName: string,
+  forceRefresh = false
+): Promise<MarketplaceManifest | null> {
+  const marketplace = await getMarketplace(marketplaceName)
+  if (!marketplace) return null
+
+  const cachePath = path.join(getCacheDir(), `${marketplaceName}.json`)
+  
+  // Check cache first unless force refresh
+  if (!forceRefresh) {
+    try {
+      const cached = await fs.readFile(cachePath, 'utf-8')
+      const manifest = JSON.parse(cached) as MarketplaceManifest
+      // Cache valid for 1 hour
+      const cacheAge = Date.now() - new Date(manifest.updatedAt).getTime()
+      if (cacheAge < 60 * 60 * 1000) {
+        return manifest
+      }
+    } catch {
+      // Cache miss or invalid, will refresh
+    }
+  }
+
+  // Discover skills from marketplace
+  const skills = await discoverSkillsFromMarketplace(marketplace)
+  
+  const manifest: MarketplaceManifest = {
+    name: marketplaceName,
+    version: '1.0',
+    skills,
+    updatedAt: new Date().toISOString(),
+  }
+
+  // Save to cache
+  await fs.writeFile(cachePath, JSON.stringify(manifest, null, 2), 'utf-8')
+  
+  return manifest
+}
+
+/** Search for a skill across all marketplaces */
+export async function searchSkill(
+  skillName: string,
+  marketplaceName?: string
+): Promise<{ skill: SkillEntry; marketplace: string }[]> {
+  const results: { skill: SkillEntry; marketplace: string }[] = []
+  
+  if (marketplaceName) {
+    const manifest = await getMarketplaceManifest(marketplaceName)
+    if (manifest) {
+      const skill = manifest.skills.find(
+        s => s.name.toLowerCase().includes(skillName.toLowerCase()) ||
+             s.description.toLowerCase().includes(skillName.toLowerCase())
+      )
+      if (skill) {
+        results.push({ skill, marketplace: marketplaceName })
+      }
+    }
+  } else {
+    // Search all marketplaces
+    const marketplaces = await listMarketplaces()
+    for (const mkt of marketplaces) {
+      const manifest = await getMarketplaceManifest(mkt.name)
+      if (manifest) {
+        for (const skill of manifest.skills) {
+          if (
+            skill.name.toLowerCase().includes(skillName.toLowerCase()) ||
+            skill.description.toLowerCase().includes(skillName.toLowerCase())
+          ) {
+            results.push({ skill, marketplace: mkt.name })
+          }
+        }
+      }
+    }
+  }
+  
+  return results
+}
+
+/** Get a skill from a marketplace by name */
+export async function getSkillByName(
+  skillName: string,
+  marketplaceName: string
+): Promise<SkillEntry | null> {
+  const manifest = await getMarketplaceManifest(marketplaceName)
+  if (!manifest) return null
+  
+  return manifest.skills.find(s => s.name === skillName) ?? null
+}

--- a/src/core/marketplace/operations.ts
+++ b/src/core/marketplace/operations.ts
@@ -1,0 +1,388 @@
+/**
+ * Marketplace operations for skilltap
+ * 
+ * Handles skill installation, uninstallation, and updates using marketplace sources.
+ * Inspired by claude-code's plugin operations system.
+ */
+
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import os from 'node:os'
+import { installSkill, uninstallSkill, listInstalled } from '../installer.js'
+import { parseSkillIdentifier } from './types.js'
+import type { 
+  Marketplace, 
+  SkillEntry, 
+  InstallResult, 
+  UninstallResult,
+  MarketplaceManifest 
+} from './types.js'
+import { 
+  listMarketplaces, 
+  getMarketplace, 
+  getMarketplaceManifest,
+  searchSkill as searchMarketplaceSkill 
+} from './manager.js'
+
+const INSTALLED_FILE = 'installed_skills.json'
+
+/** Install a skill from a local marketplace path */
+async function installFromLocalPath(
+  skill: SkillEntry,
+  marketplaceName: string,
+  marketplacePath: string,
+  installDir?: string
+): Promise<InstallResult> {
+  const targetDir = installDir ?? path.join(os.homedir(), '.agents', 'skills')
+  const sourcePath = path.join(marketplacePath, skill.path)
+  const destPath = path.join(targetDir, skill.name)
+  
+  try {
+    // Check source exists
+    await fs.access(path.join(sourcePath, 'SKILL.md'))
+  } catch {
+    return {
+      success: false,
+      message: `Skill "${skill.name}" not found at path: ${sourcePath}`,
+    }
+  }
+  
+  // Ensure target directory exists
+  await fs.mkdir(targetDir, { recursive: true })
+  
+  // Copy skill directory
+  await copyDir(sourcePath, destPath)
+  
+  // Record installation
+  const installed_data = await loadInstalledSkills()
+  const records = installed_data[skill.name] ?? []
+  records.push({
+    name: skill.name,
+    marketplace: marketplaceName,
+    version: skill.version,
+    installedAt: new Date().toISOString(),
+    lastUpdated: new Date().toISOString(),
+    installPath: destPath,
+  })
+  installed_data[skill.name] = records
+  await saveInstalledSkills(installed_data)
+  
+  return {
+    success: true,
+    message: `Successfully installed skill "${skill.name}"`,
+    skillName: skill.name,
+    path: destPath,
+  }
+}
+
+/** Recursively copy a directory */
+async function copyDir(src: string, dest: string): Promise<void> {
+  await fs.mkdir(dest, { recursive: true })
+  const entries = await fs.readdir(src, { withFileTypes: true })
+  
+  for (const entry of entries) {
+    const srcPath = path.join(src, entry.name)
+    const destPath = path.join(dest, entry.name)
+    
+    if (entry.isDirectory()) {
+      await copyDir(srcPath, destPath)
+    } else {
+      await fs.copyFile(srcPath, destPath)
+    }
+  }
+}
+
+/** Get the installed skills file path */
+function getInstalledPath(): string {
+  return path.join(os.homedir(), '.skilltap', INSTALLED_FILE)
+}
+
+/** Installed skill record */
+interface InstalledSkillRecord {
+  name: string
+  marketplace: string
+  version?: string
+  installedAt: string
+  lastUpdated: string
+  installPath: string
+}
+
+/** Load installed skills records */
+async function loadInstalledSkills(): Promise<Record<string, InstalledSkillRecord[]>> {
+  try {
+    const content = await fs.readFile(getInstalledPath(), 'utf-8')
+    return JSON.parse(content)
+  } catch {
+    return {}
+  }
+}
+
+/** Save installed skills records */
+async function saveInstalledSkills(data: Record<string, InstalledSkillRecord[]>): Promise<void> {
+  await fs.mkdir(path.dirname(getInstalledPath()), { recursive: true })
+  await fs.writeFile(getInstalledPath(), JSON.stringify(data, null, 2), 'utf-8')
+}
+
+/**
+ * Install a skill from marketplace
+ */
+export async function installFromMarketplace(
+  skillIdentifier: string,
+  installDir?: string,
+  scope: 'user' | 'project' = 'user'
+): Promise<InstallResult> {
+  const { name: skillName, marketplace: marketplaceName } = parseSkillIdentifier(skillIdentifier)
+  
+  if (!marketplaceName) {
+    // Search all marketplaces for the skill
+    const results = await searchMarketplaceSkill(skillName)
+    
+    if (results.length === 0) {
+      return {
+        success: false,
+        message: `Skill "${skillName}" not found in any marketplace`,
+      }
+    }
+    
+    if (results.length > 1) {
+      const marketplaceList = results.map(r => `${r.skill.name}@${r.marketplace}`).join(', ')
+      return {
+        success: false,
+        message: `Multiple skills found: ${marketplaceList}. Use "skill@marketplace" format to specify.`,
+      }
+    }
+    
+    const { skill, marketplace: mktName } = results[0]
+    const mkt = await getMarketplace(mktName)
+    if (!mkt) {
+      return { success: false, message: `Marketplace "${mktName}" not found` }
+    }
+    return installSkillFromEntry(skill, mkt, installDir, scope)
+  }
+  
+  // Specific marketplace
+  const marketplace = await getMarketplace(marketplaceName)
+  if (!marketplace) {
+    return {
+      success: false,
+      message: `Marketplace "${marketplaceName}" not found`,
+    }
+  }
+  
+  const manifest = await getMarketplaceManifest(marketplaceName)
+  if (!manifest) {
+    return {
+      success: false,
+      message: `Failed to load marketplace "${marketplaceName}"`,
+    }
+  }
+  
+  const skill = manifest.skills.find(s => s.name === skillName)
+  if (!skill) {
+    return {
+      success: false,
+      message: `Skill "${skillName}" not found in marketplace "${marketplaceName}"`,
+    }
+  }
+  
+  return installSkillFromEntry(skill, marketplace!, installDir, scope)
+}
+
+/**
+ * Install a skill from a marketplace entry
+ */
+async function installSkillFromEntry(
+  skill: SkillEntry,
+  marketplace: Marketplace,
+  installDir?: string,
+  scope: 'user' | 'project' = 'user'
+): Promise<InstallResult> {
+  try {
+    // Handle local marketplace
+    if (marketplace.type === 'local' && marketplace.path) {
+      return installFromLocalPath(skill, marketplace.name, marketplace.path, installDir)
+    }
+    
+    // Handle GitHub marketplace
+    const { owner, repo, branch } = skill.source
+    
+    if (!owner || !repo) {
+      return {
+        success: false,
+        message: `Skill "${skill.name}" does not have valid source information`,
+      }
+    }
+    
+    const installed = await installSkill(
+      { owner, repo, branch },
+      skill.name,
+      installDir
+    )
+    
+    // Record installation
+    const installed_data = await loadInstalledSkills()
+    const records = installed_data[skill.name] ?? []
+    
+    // Remove existing record for same scope if exists
+    const filteredRecords = records.filter(r => r.marketplace !== marketplaceName)
+    
+    filteredRecords.push({
+      name: skill.name,
+      marketplace: marketplaceName,
+      version: skill.version,
+      installedAt: new Date().toISOString(),
+      lastUpdated: new Date().toISOString(),
+      installPath: installed.path,
+    })
+    
+    installed_data[skill.name] = filteredRecords
+    await saveInstalledSkills(installed_data)
+    
+    return {
+      success: true,
+      message: `Successfully installed skill "${skill.name}" from marketplace "${marketplaceName}"`,
+      skillName: skill.name,
+      path: installed.path,
+      marketplace: marketplaceName,
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    return {
+      success: false,
+      message: `Failed to install "${skill.name}": ${message}`,
+    }
+  }
+}
+
+/**
+ * Uninstall a skill
+ */
+export async function uninstallFromMarketplace(
+  skillName: string,
+  marketplaceName?: string
+): Promise<UninstallResult> {
+  try {
+    const installed_data = await loadInstalledSkills()
+    const records = installed_data[skillName] ?? []
+    
+    if (records.length === 0) {
+      return {
+        success: false,
+        message: `Skill "${skillName}" is not installed`,
+      }
+    }
+    
+    // Find record to uninstall
+    let recordToRemove: InstalledSkillRecord | undefined
+    let remainingRecords: InstalledSkillRecord[] = []
+    
+    if (marketplaceName) {
+      recordToRemove = records.find(r => r.marketplace === marketplaceName)
+      remainingRecords = records.filter(r => r.marketplace !== marketplaceName)
+    } else {
+      // Remove first record if no marketplace specified
+      recordToRemove = records[0]
+      remainingRecords = records.slice(1)
+    }
+    
+    if (!recordToRemove) {
+      return {
+        success: false,
+        message: `Skill "${skillName}" is not installed from marketplace "${marketplaceName}"`,
+      }
+    }
+    
+    // Uninstall from filesystem
+    await uninstallSkill(skillName, recordToRemove.installPath)
+    
+    // Update records
+    if (remainingRecords.length > 0) {
+      installed_data[skillName] = remainingRecords
+    } else {
+      delete installed_data[skillName]
+    }
+    await saveInstalledSkills(installed_data)
+    
+    return {
+      success: true,
+      message: `Successfully uninstalled skill "${skillName}"`,
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    return {
+      success: false,
+      message: `Failed to uninstall "${skillName}": ${message}`,
+    }
+  }
+}
+
+/**
+ * List installed skills with marketplace info
+ */
+export async function listInstalledWithMarketplace(): Promise<InstalledSkillRecord[]> {
+  const installed_data = await loadInstalledSkills()
+  const records: InstalledSkillRecord[] = []
+  
+  for (const skillRecords of Object.values(installed_data)) {
+    records.push(...skillRecords)
+  }
+  
+  return records
+}
+
+/**
+ * Search for a skill across marketplaces
+ */
+export async function search(
+  keyword: string,
+  marketplaceName?: string
+): Promise<{ skill: SkillEntry; marketplace: string }[]> {
+  return searchMarketplaceSkill(keyword, marketplaceName)
+}
+
+/**
+ * Update a skill to latest version
+ */
+export async function updateSkill(
+  skillName: string,
+  marketplaceName?: string
+): Promise<InstallResult> {
+  const installed_data = await loadInstalledSkills()
+  const records = installed_data[skillName] ?? []
+  
+  const targetMarketplace = marketplaceName ?? records[0]?.marketplace
+  if (!targetMarketplace) {
+    return {
+      success: false,
+      message: `Skill "${skillName}" is not installed`,
+    }
+  }
+  
+  const record = records.find(r => r.marketplace === targetMarketplace)
+  if (!record) {
+    return {
+      success: false,
+      message: `Skill "${skillName}" is not installed from marketplace "${targetMarketplace}"`,
+    }
+  }
+  
+  // Re-install to update
+  return installFromMarketplace(`${skillName}@${targetMarketplace}`, record.installPath)
+}
+
+/**
+ * Update all installed skills
+ */
+export async function updateAll(): Promise<InstallResult[]> {
+  const results: InstallResult[] = []
+  const installed_data = await loadInstalledSkills()
+  
+  for (const [skillName, records] of Object.entries(installed_data)) {
+    for (const record of records) {
+      const result = await updateSkill(skillName, record.marketplace)
+      results.push(result)
+    }
+  }
+  
+  return results
+}

--- a/src/core/marketplace/types.ts
+++ b/src/core/marketplace/types.ts
@@ -1,0 +1,100 @@
+/**
+ * Marketplace types for skilltap
+ * 
+ * Defines the structure for marketplace-based skill browsing and installation,
+ * inspired by claude-code's plugin marketplace system.
+ */
+
+/** Skill metadata from marketplace entry */
+export interface SkillEntry {
+  name: string
+  description: string
+  author?: string
+  version?: string
+  license?: string
+  argumentHint?: string
+  /** Path to the skill directory in the marketplace */
+  path: string
+  /** Source repository info */
+  source: {
+    owner: string
+    repo: string
+    branch?: string
+  }
+}
+
+/** A configured marketplace source */
+export interface Marketplace {
+  /** Unique marketplace name */
+  name: string
+  /** Source type */
+  type: 'github' | 'url' | 'local'
+  /** GitHub repo for 'github' type */
+  repo?: string
+  /** URL for 'url' type */
+  url?: string
+  /** Local path for 'local' type */
+  path?: string
+  /** Optional branch for GitHub */
+  branch?: string
+  /** Auto-update enabled */
+  autoUpdate?: boolean
+  /** When this marketplace was added */
+  addedAt: string
+}
+
+/** Marketplace manifest containing all available skills */
+export interface MarketplaceManifest {
+  /** Marketplace name */
+  name: string
+  /** Marketplace version for caching */
+  version: string
+  /** Skills in this marketplace */
+  skills: SkillEntry[]
+  /** Last updated timestamp */
+  updatedAt: string
+}
+
+/** Skill installation result */
+export interface InstallResult {
+  success: boolean
+  message: string
+  skillName?: string
+  path?: string
+  marketplace?: string
+}
+
+/** Skill uninstallation result */
+export interface UninstallResult {
+  success: boolean
+  message: string
+}
+
+/** Marketplace configuration */
+export interface MarketplaceConfig {
+  version: string
+  marketplaces: Record<string, MarketplaceConfigEntry>
+}
+
+/** Marketplace config entry */
+export interface MarketplaceConfigEntry {
+  type: 'github' | 'url' | 'local'
+  repo?: string
+  url?: string
+  path?: string
+  branch?: string
+  autoUpdate?: boolean
+  addedAt: string
+}
+
+/** Parse plugin identifier like "skill@marketplace" */
+export function parseSkillIdentifier(identifier: string): {
+  name: string
+  marketplace: string | null
+} {
+  const parts = identifier.split('@')
+  if (parts.length === 2 && parts[0] && parts[1]) {
+    return { name: parts[0], marketplace: parts[1] }
+  }
+  return { name: identifier, marketplace: null }
+}


### PR DESCRIPTION
## Summary

Add marketplace-based skill browsing and installation, inspired by claude-code's plugin marketplace system.

## Changes

### New Commands
- skilltap marketplace list - List configured marketplaces
- skilltap marketplace add - Add a marketplace
- skilltap browse - Browse skills in marketplace
- skilltap search - Search for skills across marketplaces

### Marketplace Types
- github: owner/repo format
- url: https:// URLs
- local: local directory paths

## Architecture
- src/core/marketplace/types.ts
- src/core/marketplace/manager.ts  
- src/core/marketplace/operations.ts
- src/cli/marketplace.ts

## Testing
Local marketplace verified. GitHub API may timeout without token/proxy.