### PR TITLE
feat: support private repo access in marketplace

### DIFF
--- a/src/cli/marketplace.ts
+++ b/src/cli/marketplace.ts
@@ -43,7 +43,8 @@ export function createMarketplaceCommands(program: Command): void {
     .description('Add a marketplace (e.g., skilltap marketplace add myskills github/anthropics/skills)')
     .option('-b, --branch <branch>', 'Branch for GitHub repos')
     .option('-t, --token <token>', 'GitHub token for private repos')
-    .action(async (name: string, source: string, opts: { branch?: string; token?: string }) => {
+    .option('-s, --scan-path <path>', 'Custom path within repo to scan for skills (e.g. .agents/skills)')
+    .action(async (name: string, source: string, opts: { branch?: string; token?: string; scanPath?: string }) => {
       try {
         // Parse source format: github/owner/repo, url/http://..., or local/path
         if (source.startsWith('http://') || source.startsWith('https://')) {
@@ -56,11 +57,11 @@ export function createMarketplaceCommands(program: Command): void {
         } else if (source.startsWith('github/')) {
           // github/owner/repo format
           const repo = source.slice('github/'.length)
-          await addMarketplace(name, 'github', { repo, branch: opts.branch, token: opts.token })
+          await addMarketplace(name, 'github', { repo, branch: opts.branch, token: opts.token, scanPath: opts.scanPath })
           console.log(`Added marketplace "${name}" from GitHub: ${repo}`)
         } else if (source.includes('/') && source.split('/').length === 2) {
           // owner/repo format (exactly 2 parts)
-          await addMarketplace(name, 'github', { repo: source, branch: opts.branch, token: opts.token })
+          await addMarketplace(name, 'github', { repo: source, branch: opts.branch, token: opts.token, scanPath: opts.scanPath })
           console.log(`Added marketplace "${name}" from GitHub: ${source}`)
         } else {
           console.error(`Invalid source format: ${source}`)

--- a/src/core/marketplace/manager.ts
+++ b/src/core/marketplace/manager.ts
@@ -69,7 +69,7 @@ async function saveMarketplaceConfig(config: MarketplaceConfig): Promise<void> {
 export async function addMarketplace(
   name: string,
   type: 'github' | 'url' | 'local',
-  options: { repo?: string; url?: string; path?: string; branch?: string; token?: string } = {}
+  options: { repo?: string; url?: string; path?: string; branch?: string; token?: string; scanPath?: string } = {}
 ): Promise<Marketplace> {
   const config = await loadMarketplaceConfig()
   
@@ -155,7 +155,7 @@ export async function discoverSkillsFromMarketplace(
       const discovered = await findSkills(
         { owner, repo, branch: marketplace.branch },
         token,
-        '' // repo root
+        marketplace.scanPath ?? '' // repo root or custom scan path
       )
       
       for (const skill of discovered) {

--- a/src/core/marketplace/types.ts
+++ b/src/core/marketplace/types.ts
@@ -41,6 +41,8 @@ export interface Marketplace {
   autoUpdate?: boolean
   /** GitHub token for private repos */
   token?: string
+  /** Custom path within the repo to scan for skills (e.g. '.agents/skills') */
+  scanPath?: string
   /** When this marketplace was added */
   addedAt: string
 }
@@ -88,6 +90,8 @@ export interface MarketplaceConfigEntry {
   autoUpdate?: boolean
   /** GitHub token for private repos */
   token?: string
+  /** Custom path within the repo to scan for skills (e.g. '.agents/skills') */
+  scanPath?: string
   addedAt: string
 }
 


### PR DESCRIPTION
Support private GitHub repos in marketplace discovery:
- Auto-detect GitHub token from `gh auth`, `GITHUB_TOKEN` env, or per-marketplace token
- Add `--scan-path` to scan subdirectories (e.g. `.agents/skills`)

E2E verified: 14 skills from `eddiearc/obsidian-personal` successfully discovered.