### PR TITLE
fix: scan .agents and .claude directories for skills

### DIFF
--- a/src/core/marketplace/manager.ts
+++ b/src/core/marketplace/manager.ts
@@ -184,6 +184,8 @@ export async function discoverSkillsFromMarketplace(
   return skills
 }
 
+const SKIP_DIRS = new Set(['.git', '.github', '.vscode', '.idea', 'node_modules'])
+
 /** Recursively scan a local directory for skills */
 async function scanLocalSkills(
   dirPath: string,
@@ -196,7 +198,7 @@ async function scanLocalSkills(
     const entries = await fs.readdir(dirPath, { withFileTypes: true })
 
     for (const entry of entries) {
-      if (!entry.isDirectory() || entry.name.startsWith('.')) continue
+      if (!entry.isDirectory() || SKIP_DIRS.has(entry.name)) continue
 
       const fullPath = path.join(dirPath, entry.name)
       const skillMdPath = path.join(fullPath, 'SKILL.md')

--- a/tests/core/marketplace/manager.test.ts
+++ b/tests/core/marketplace/manager.test.ts
@@ -340,6 +340,79 @@ describe('discoverSkillsFromMarketplace', () => {
   })
 })
 
+  it('discovers skills inside .agents and .claude directories', async () => {
+    vi.mocked(cloneOrUpdate).mockResolvedValue('/fake/cache')
+
+    // Root has .agents, .claude, and .git directories
+    let readdirCallCount = 0
+    vi.mocked(fs.readdir).mockImplementation(async () => {
+      readdirCallCount++
+      if (readdirCallCount === 1) {
+        // Root level
+        return [
+          { name: '.git', isDirectory: () => true, isFile: () => false },
+          { name: '.agents', isDirectory: () => true, isFile: () => false },
+          { name: '.claude', isDirectory: () => true, isFile: () => false },
+          { name: 'node_modules', isDirectory: () => true, isFile: () => false },
+        ] as any
+      }
+      if (readdirCallCount === 2) {
+        // .agents dir
+        return [{ name: 'agent-skill', isDirectory: () => true, isFile: () => false }] as any
+      }
+      if (readdirCallCount === 3) {
+        // .claude dir
+        return [{ name: 'claude-skill', isDirectory: () => true, isFile: () => false }] as any
+      }
+      return []
+    })
+
+    vi.mocked(fs.readFile).mockImplementation(async (filePath: any) => {
+      const fp = String(filePath)
+      if (fp.includes('agent-skill') && fp.endsWith('SKILL.md')) {
+        return `---\nname: agent-skill\ndescription: From .agents\n---\n`
+      }
+      if (fp.includes('claude-skill') && fp.endsWith('SKILL.md')) {
+        return `---\nname: claude-skill\ndescription: From .claude\n---\n`
+      }
+      throw new Error('ENOENT')
+    })
+
+    const marketplace: Marketplace = {
+      name: 'test-mkt',
+      type: 'git',
+      gitUrl: 'https://github.com/org/repo.git',
+      addedAt: '2026-01-01',
+    }
+
+    const skills = await discoverSkillsFromMarketplace(marketplace)
+    expect(skills).toHaveLength(2)
+    const names = skills.map(s => s.name).sort()
+    expect(names).toEqual(['agent-skill', 'claude-skill'])
+  })
+
+  it('skips .git and node_modules directories', async () => {
+    vi.mocked(cloneOrUpdate).mockResolvedValue('/fake/cache')
+
+    vi.mocked(fs.readdir).mockResolvedValueOnce([
+      { name: '.git', isDirectory: () => true, isFile: () => false },
+      { name: 'node_modules', isDirectory: () => true, isFile: () => false },
+      { name: '.github', isDirectory: () => true, isFile: () => false },
+      { name: '.vscode', isDirectory: () => true, isFile: () => false },
+      { name: '.idea', isDirectory: () => true, isFile: () => false },
+    ] as any)
+
+    const marketplace: Marketplace = {
+      name: 'test-mkt',
+      type: 'git',
+      gitUrl: 'https://github.com/org/repo.git',
+      addedAt: '2026-01-01',
+    }
+
+    const skills = await discoverSkillsFromMarketplace(marketplace)
+    expect(skills).toHaveLength(0)
+  })
+
 // --- parseFrontmatter (tested indirectly via discoverSkillsFromMarketplace) ---
 // The parseFrontmatter function is not exported, but we test it through skill discovery.
 // Additional frontmatter edge cases are covered in github.test.ts since it shares the same logic.


### PR DESCRIPTION
## Summary
- Replace blanket `entry.name.startsWith('.')` skip with targeted `SKIP_DIRS` set (`.git`, `.github`, `.vscode`, `.idea`, `node_modules`)
- Skills in `.agents/skills/` and `.claude/skills/` are now discoverable

## Test plan
- [x] Added test: discovers skills inside `.agents` and `.claude` directories
- [x] Added test: still skips `.git`, `.github`, `.vscode`, `.idea`, `node_modules`
- [x] All 119 tests pass

Fixes #15